### PR TITLE
feat: raise tool definitions to TDQS tier A with MCP annotations

### DIFF
--- a/BUG_REPORT.md
+++ b/BUG_REPORT.md
@@ -56,7 +56,7 @@
 
 Additionally, `ResourceRef` (operations.go:9-13) uses `"parent,omitempty"` which omits parent for hosts, but the API requires `"parent": null` for hosts.
 
-**Fix required in**: `centreon-go-client` — restructure all operation request structs with wrapper objects, and always include `parent` (null for hosts).
+**Fix required in**: `centreon-go-client`: restructure all operation request structs with wrapper objects, and always include `parent` (null for hosts).
 
 ---
 
@@ -96,12 +96,12 @@ The `with_services` field lacks `omitempty`, so even when `false` it's included 
 | `centreon_user_update` | `PATCH /centreon/api/latest/users/{id}` | 404 |
 
 **Code locations** (centreon-go-client):
-- `users.go:34` — `/users`
-- `contact_groups.go:25` — `/users/contact-groups`
-- `contact_templates.go:24` — `/users/contact-templates`
-- `user_filters.go:49` — `/users/filters`
+- `users.go:34`: `/users`
+- `contact_groups.go:25`: `/users/contact-groups`
+- `contact_templates.go:24`: `/users/contact-templates`
+- `user_filters.go:49`: `/users/filters`
 
-**Fix required in**: `centreon-go-client` — correct the API endpoint paths. These may need to be under `/configuration/users` or similar depending on the Centreon API version.
+**Fix required in**: `centreon-go-client`: correct the API endpoint paths. These may need to be under `/configuration/users` or similar depending on the Centreon API version.
 
 ---
 
@@ -140,7 +140,7 @@ The Centreon API requires `days` (array of day/time_range objects) and `template
 
 **Error**: `HTTP 400: The property alias is not defined and the definition does not allow additional properties`
 
-**Code location**: `tools/service_tools.go` — `ServiceUpdateInput` struct includes `Alias` field, but the Centreon service update API does not accept `alias`.
+**Code location**: `tools/service_tools.go`: `ServiceUpdateInput` struct includes `Alias` field, but the Centreon service update API does not accept `alias`.
 
 ---
 
@@ -158,7 +158,7 @@ The Centreon API requires `days` (array of day/time_range objects) and `template
 
 The search parameter uses `Lk("name", ...)` which generates `{"name": {"$lk": "..."}}`. The monitoring host list endpoint does not accept this search format.
 
-**Code location**: `tools/tools.go:141-143` — `buildListOptions()` applies the same search strategy to all endpoints, but monitoring endpoints have different search parameter support.
+**Code location**: `tools/tools.go:141-143`: `buildListOptions()` applies the same search strategy to all endpoints, but monitoring endpoints have different search parameter support.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Exposes 88 tools covering real-time monitoring, host and service configuration, 
 
 ## Features
 
-- **88 tools** across 11 categories — monitoring, operations, downtimes, acknowledgements, host config, service config, infrastructure, users, notifications, platform status, and connection testing
-- **Three transport modes** — stdio (default), HTTP (streamable), and HTTP gateway mode
+- **88 tools** across 11 categories: monitoring, operations, downtimes, acknowledgements, host config, service config, infrastructure, users, notifications, platform status, and connection testing
+- **Three transport modes**: stdio (default), HTTP (streamable), and HTTP gateway mode
 - **Structured JSON logging** via `log/slog` with configurable levels
-- **Gateway mode with token cache** — per-request Centreon credentials via HTTP headers, with a 50-minute token cache to avoid repeated logins
-- **Self-signed certificate support** — opt-in via `CENTREON_ALLOW_SELF_SIGNED`
+- **Gateway mode with token cache**: per-request Centreon credentials via HTTP headers, with a 50-minute token cache to avoid repeated logins
+- **Self-signed certificate support**: opt-in via `CENTREON_ALLOW_SELF_SIGNED`
 
 ## Requirements
 
@@ -56,10 +56,10 @@ All configuration is via environment variables.
 
 | Variable                    | Required | Default     | Description                                                  |
 |-----------------------------|----------|-------------|--------------------------------------------------------------|
-| `CENTREON_HOST`             | Yes      | —           | Centreon server base URL (e.g. `https://centreon.example.com`) |
-| `CENTREON_USERNAME`         | *        | —           | Username for session-based authentication                    |
-| `CENTREON_PASSWORD`         | *        | —           | Password for session-based authentication                    |
-| `CENTREON_TOKEN`            | *        | —           | API token (alternative to username + password)               |
+| `CENTREON_HOST`             | Yes      | (none)      | Centreon server base URL (e.g. `https://centreon.example.com`) |
+| `CENTREON_USERNAME`         | *        | (none)      | Username for session-based authentication                    |
+| `CENTREON_PASSWORD`         | *        | (none)      | Password for session-based authentication                    |
+| `CENTREON_TOKEN`            | *        | (none)      | API token (alternative to username + password)               |
 | `CENTREON_ALLOW_SELF_SIGNED`| No       | `false`     | Accept self-signed TLS certificates                          |
 | `MCP_TRANSPORT`             | No       | `stdio`     | Transport mode: `stdio` or `http`                            |
 | `MCP_HTTP_PORT`             | No       | `8080`      | HTTP listen port (HTTP transport only)                       |
@@ -106,7 +106,7 @@ To use an API token instead:
 
 ## Usage with Claude Desktop
 
-Add the server to `claude_desktop_config.json` (location varies by OS — check the Claude Desktop documentation):
+Add the server to `claude_desktop_config.json` (location varies by OS, so check the Claude Desktop documentation):
 
 ```json
 {
@@ -149,7 +149,7 @@ Configure your MCP client to connect to `http://localhost:8080/mcp`.
 
 Gateway mode is for multi-tenant or shared deployments where each request carries its own Centreon credentials. The server creates a per-request Centreon client authenticated with the supplied credentials.
 
-Enable it with `AUTH_MODE=gateway` alongside `MCP_TRANSPORT=http`. In this mode, `CENTREON_HOST`, `CENTREON_USERNAME`, `CENTREON_PASSWORD`, and `CENTREON_TOKEN` are not required at startup — they are provided per request via HTTP headers.
+Enable it with `AUTH_MODE=gateway` alongside `MCP_TRANSPORT=http`. In this mode, `CENTREON_HOST`, `CENTREON_USERNAME`, `CENTREON_PASSWORD`, and `CENTREON_TOKEN` are not required at startup; they are provided per request via HTTP headers.
 
 | Header                  | Description                                         |
 |-------------------------|-----------------------------------------------------|
@@ -205,7 +205,7 @@ This project uses [Task](https://taskfile.dev) for development commands.
 | Command          | Description                                   |
 |------------------|-----------------------------------------------|
 | `task check`     | Run all local checks: fmt, tidy, vet, lint, test |
-| `task ci`        | Full CI pipeline — check then build           |
+| `task ci`        | Full CI pipeline: check then build            |
 | `task go:build`  | Build the binary                              |
 | `task go:run`    | Run the server in stdio mode                  |
 | `task go:test`   | Run tests with race detector                  |

--- a/tools/acknowledgement_tools.go
+++ b/tools/acknowledgement_tools.go
@@ -12,42 +12,50 @@ import (
 func RegisterAcknowledgementTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_acknowledgement_list",
-		Description: "List all acknowledgements. Supports pagination and filtering.",
+		Description: "Retrieve a paginated list of all acknowledgements across every host and service on the platform, where each acknowledgement marks a problem as seen so it stops sending notifications. Use this for a platform-wide view; scope to one host with centreon_acknowledgement_host_list, to one service with centreon_acknowledgement_service_list, or fetch a single record by ID with centreon_acknowledgement_get. Supports page (default 1), limit (default 30, max 100), and a search filter matched against the name. Read-only.",
+		Annotations: readOnlyTool("List acknowledgements"),
 	}, acknowledgementListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_acknowledgement_get",
-		Description: "Get a single acknowledgement by ID.",
+		Description: "Fetch a single acknowledgement by its numeric id and return its full stored detail. Use this when you already know the id; to discover ids, browse with centreon_acknowledgement_list for the whole platform, centreon_acknowledgement_host_list for one host, or centreon_acknowledgement_service_list for one service. Requires the id field and takes no pagination. Read-only.",
+		Annotations: readOnlyTool("Get acknowledgement"),
 	}, acknowledgementGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_acknowledgement_host_list",
-		Description: "List acknowledgements for a specific host.",
+		Description: "List the acknowledgements recorded for one host, identified by the required hostID. Use this to inspect a single host; for a service on that host use centreon_acknowledgement_service_list, and for every acknowledgement on the platform use centreon_acknowledgement_list. Supports page (default 1), limit (default 30, max 100), and a name search filter. Read-only.",
+		Annotations: readOnlyTool("List host acknowledgements"),
 	}, acknowledgementHostListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_acknowledgement_service_list",
-		Description: "List acknowledgements for a specific service on a host.",
+		Description: "List the acknowledgements recorded for one service, identified by both its hostID and serviceID. Use this to inspect a single service; for the parent host use centreon_acknowledgement_host_list, and for every acknowledgement on the platform use centreon_acknowledgement_list. Supports page (default 1), limit (default 30, max 100), and a name search filter. Read-only.",
+		Annotations: readOnlyTool("List service acknowledgements"),
 	}, acknowledgementServiceListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_acknowledgement_host_create",
-		Description: "Acknowledge a specific host.",
+		Description: "Acknowledge a down or unreachable host, identified by hostID, so Centreon marks the problem as handled and stops resending notifications for it. Use this for a host-level problem; to acknowledge a single failing service use centreon_acknowledgement_service_create, and to clear an existing host acknowledgement use centreon_acknowledgement_host_cancel. Requires hostID and a comment; optional flags set sticky (stays until recovery), notify contacts, persistent comment, and withServices to also acknowledge every service on the host. Writes to Centreon.",
+		Annotations: createTool("Acknowledge host problem"),
 	}, acknowledgementHostCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_acknowledgement_service_create",
-		Description: "Acknowledge a specific service on a host.",
+		Description: "Acknowledge a warning, critical, or unknown service on a host, identified by hostID and serviceID, so Centreon marks the problem as handled and stops resending its notifications. Use this for a single service; to acknowledge the whole host use centreon_acknowledgement_host_create, and to clear an existing service acknowledgement use centreon_acknowledgement_service_cancel. Requires hostID, serviceID, and a comment; optional flags set sticky (stays until recovery), notify contacts, and persistent comment. Writes to Centreon.",
+		Annotations: createTool("Acknowledge service problem"),
 	}, acknowledgementServiceCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_acknowledgement_host_cancel",
-		Description: "Cancel the acknowledgement for a specific host.",
+		Description: "Remove the current acknowledgement from a host, identified by hostID, which re-enables normal problem notifications while the host is still down or unreachable. Use this to reverse centreon_acknowledgement_host_create; to clear a service acknowledgement instead use centreon_acknowledgement_service_cancel. Requires only hostID and takes no comment. Writes to Centreon.",
+		Annotations: deleteTool("Cancel host acknowledgement"),
 	}, acknowledgementHostCancelHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_acknowledgement_service_cancel",
-		Description: "Cancel the acknowledgement for a specific service on a host.",
+		Description: "Remove the current acknowledgement from a service, identified by hostID and serviceID, which re-enables normal problem notifications while the service is still in a non-ok state. Use this to reverse centreon_acknowledgement_service_create; to clear a host acknowledgement instead use centreon_acknowledgement_host_cancel. Requires hostID and serviceID and takes no comment. Writes to Centreon.",
+		Annotations: deleteTool("Cancel service acknowledgement"),
 	}, acknowledgementServiceCancelHandler(client, logger))
 }
 

--- a/tools/connection_tools.go
+++ b/tools/connection_tools.go
@@ -12,7 +12,8 @@ import (
 func RegisterConnectionTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_connection_test",
-		Description: "Test connectivity to the Centreon API by performing a lightweight status check.",
+		Description: "Verify that the configured Centreon API credentials authenticate and the API is reachable by fetching host status counts. Takes no arguments; call this first to confirm connectivity before using other tools. Read-only.",
+		Annotations: readOnlyTool("Test connection"),
 	}, connectionTestHandler(client, logger))
 }
 

--- a/tools/downtime_tools.go
+++ b/tools/downtime_tools.go
@@ -13,47 +13,56 @@ import (
 func RegisterDowntimeTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_list",
-		Description: "List all scheduled downtimes. Supports pagination and filtering.",
+		Description: "Retrieve scheduled maintenance windows across the entire platform, spanning every host and service, that suppress notifications during planned outages. Use this for a platform-wide view; narrow to one host with centreon_downtime_host_list or one service with centreon_downtime_service_list, and fetch a single window by ID with centreon_downtime_get. Paginated (page 1, limit 30, max 100 per page) with optional name search. Read-only.",
+		Annotations: readOnlyTool("List downtimes"),
 	}, downtimeListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_get",
-		Description: "Get a single scheduled downtime by ID.",
+		Description: "Fetch the complete detail of one scheduled maintenance window identified by its numeric downtime ID, including its comment, start and end times, and fixed or flexible type. Use this when you already hold the ID; discover IDs first with centreon_downtime_list, centreon_downtime_host_list, or centreon_downtime_service_list. Returns a single record. Read-only.",
+		Annotations: readOnlyTool("Get downtime"),
 	}, downtimeGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_cancel",
-		Description: "Cancel a scheduled downtime by ID.",
+		Description: "Cancel one scheduled maintenance window by its numeric downtime ID, ending the notification suppression it applied. Use this to remove a single window; cancel every window on a host with centreon_downtime_host_cancel or every window on a service with centreon_downtime_service_cancel, and schedule a new window with centreon_downtime_host_create or centreon_downtime_service_create. Removes the identified downtime. Writes to Centreon.",
+		Annotations: deleteTool("Cancel downtime"),
 	}, downtimeCancelHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_host_list",
-		Description: "List scheduled downtimes for a specific host.",
+		Description: "List the scheduled maintenance windows attached to one host identified by its host ID. Use this to scope results to a single host; list every window platform-wide with centreon_downtime_list, or restrict to one service on the host with centreon_downtime_service_list. Paginated (page 1, limit 30, max 100 per page) with optional name search. Read-only.",
+		Annotations: readOnlyTool("List host downtimes"),
 	}, downtimeHostListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_service_list",
-		Description: "List scheduled downtimes for a specific service on a host.",
+		Description: "List the scheduled maintenance windows attached to one service, identified by its host ID and service ID together. Use this to scope results to a single service; widen to every window on the host with centreon_downtime_host_list or the whole platform with centreon_downtime_list. Paginated (page 1, limit 30, max 100 per page) with optional name search. Read-only.",
+		Annotations: readOnlyTool("List service downtimes"),
 	}, downtimeServiceListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_host_create",
-		Description: "Schedule a downtime for a specific host.",
+		Description: "Schedule a maintenance window on one host so its notifications are suppressed between a start and end time, optionally covering every service on the host. Use this for host-level downtime; schedule a single service instead with centreon_downtime_service_create, and remove a window with centreon_downtime_host_cancel or centreon_downtime_cancel. Requires hostID, a comment, and RFC3339 startTime and endTime with endTime after startTime; set isFixed for a fixed window or supply duration in seconds for a flexible one, and set withServices to include all of the host's services. Writes to Centreon.",
+		Annotations: createTool("Schedule host downtime"),
 	}, downtimeHostCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_service_create",
-		Description: "Schedule a downtime for a specific service on a host.",
+		Description: "Schedule a maintenance window on one service, identified by its host ID and service ID, so only that service's notifications are suppressed between a start and end time. Use this for a single service; cover an entire host with centreon_downtime_host_create, and remove a window with centreon_downtime_service_cancel or centreon_downtime_cancel. Requires hostID, serviceID, a comment, and RFC3339 startTime and endTime with endTime after startTime; set isFixed for a fixed window or supply duration in seconds for a flexible one. Writes to Centreon.",
+		Annotations: createTool("Schedule service downtime"),
 	}, downtimeServiceCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_host_cancel",
-		Description: "Cancel all scheduled downtimes for a specific host.",
+		Description: "Cancel every scheduled maintenance window currently attached to one host, identified by its host ID, restoring that host's notifications. Use this to clear a host in bulk; remove a single window by ID with centreon_downtime_cancel, or clear one service with centreon_downtime_service_cancel. Removes all of the host's downtimes in one call. Writes to Centreon.",
+		Annotations: deleteTool("Cancel host downtimes"),
 	}, downtimeHostCancelHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_downtime_service_cancel",
-		Description: "Cancel all scheduled downtimes for a specific service on a host.",
+		Description: "Cancel every scheduled maintenance window currently attached to one service, identified by its host ID and service ID, restoring that service's notifications. Use this to clear a service in bulk; clear the whole host with centreon_downtime_host_cancel, or remove a single window by ID with centreon_downtime_cancel. Removes all of the service's downtimes in one call. Writes to Centreon.",
+		Annotations: deleteTool("Cancel service downtimes"),
 	}, downtimeServiceCancelHandler(client, logger))
 }
 

--- a/tools/host_config_tools.go
+++ b/tools/host_config_tools.go
@@ -12,107 +12,128 @@ import (
 func RegisterHostConfigTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_list",
-		Description: "List host configurations. Supports pagination and name filtering.",
+		Description: "Retrieve a paginated list of configured hosts (the machines and devices Centreon monitors) with their IDs, names, and addresses. Use this to discover host IDs or browse the inventory; for one host's full configuration by ID use centreon_host_get, and for live up/down state use centreon_monitoring_host_list. Supports page (default 1), limit (default 30, max 100), and name search, and returns stored configuration only. Read-only.",
+		Annotations: readOnlyTool("List hosts"),
 	}, hostListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_get",
-		Description: "Get a single host configuration by ID.",
+		Description: "Fetch the full stored configuration of a single host by its numeric ID, including address, templates, groups, categories, and check settings. Use this when you already know the host ID; to search or page through hosts use centreon_host_list, and for current up/down monitoring state use centreon_monitoring_host_get. Requires id and returns configuration only, never live status. Read-only.",
+		Annotations: readOnlyTool("Get host"),
 	}, hostGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_create",
-		Description: "Create a new host configuration.",
+		Description: "Define a new host by attaching it to a monitoring server with a name and an IP address or FQDN, plus optional templates, groups, categories, and macros. Use this to add a machine to monitoring; to change an existing host use centreon_host_update, and to remove one use centreon_host_delete. Requires monitoringServerID, name, and address, and the new host stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: createTool("Create host"),
 	}, hostCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_update",
-		Description: "Update an existing host configuration (partial update).",
+		Description: "Modify selected fields of an existing host such as name, address, check command, check intervals, or activation, leaving unspecified fields untouched. Use this to edit a host previously added with centreon_host_create; to create a host use centreon_host_create and to remove one use centreon_host_delete. Requires id, applies a partial update, and the change stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: updateTool("Update host"),
 	}, hostUpdateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_delete",
-		Description: "Delete a host configuration by ID.",
+		Description: "Permanently remove a host from the configuration by its numeric ID. Use this to decommission a machine; to change it instead of removing it use centreon_host_update, and to inspect it first use centreon_host_get. Requires id, and the deletion stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: deleteTool("Delete host"),
 	}, hostDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_group_list",
-		Description: "List host group configurations. Supports pagination and name filtering.",
+		Description: "Retrieve a paginated list of host groups, the named collections that bundle related hosts together for dashboards and filtering. Use this to discover host group IDs; for one group's details by ID use centreon_host_group_get. Supports page (default 1), limit (default 30, max 100), and name search, and returns stored configuration only. Read-only.",
+		Annotations: readOnlyTool("List host groups"),
 	}, hostGroupListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_group_get",
-		Description: "Get a single host group configuration by ID.",
+		Description: "Fetch the stored configuration of a single host group by its numeric ID, including its name and alias. Use this when you already know the group ID; to search or page through host groups use centreon_host_group_list. Requires id and returns configuration only. Read-only.",
+		Annotations: readOnlyTool("Get host group"),
 	}, hostGroupGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_group_create",
-		Description: "Create a new host group configuration.",
+		Description: "Define a new host group, a named container for organizing hosts, with a name and optional alias. Use this to add a grouping; to rename an existing group use centreon_host_group_update, and to remove one use centreon_host_group_delete. Requires name, and the new group stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: createTool("Create host group"),
 	}, hostGroupCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_group_update",
-		Description: "Replace an existing host group configuration (full update).",
+		Description: "Overwrite the name and alias of an existing host group identified by its numeric ID. Use this to rename or re-describe a group added with centreon_host_group_create; to create a group use centreon_host_group_create and to remove one use centreon_host_group_delete. Requires id and name, replaces both fields, and the change stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: updateTool("Update host group"),
 	}, hostGroupUpdateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_group_delete",
-		Description: "Delete a host group configuration by ID.",
+		Description: "Remove a host group by its numeric ID, dissolving the grouping while leaving the member hosts in place. Use this to drop an unused collection; to rename it instead use centreon_host_group_update, and to inspect it first use centreon_host_group_get. Requires id, and the deletion stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: deleteTool("Delete host group"),
 	}, hostGroupDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_category_list",
-		Description: "List host category configurations. Supports pagination and name filtering.",
+		Description: "Retrieve a paginated list of host categories, the classification tags used to label and organize hosts independently of host groups. Use this to discover category IDs; for one category's details by ID use centreon_host_category_get. Supports page (default 1), limit (default 30, max 100), and name search, and returns stored configuration only. Read-only.",
+		Annotations: readOnlyTool("List host categories"),
 	}, hostCategoryListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_category_get",
-		Description: "Get a single host category configuration by ID.",
+		Description: "Fetch the stored configuration of a single host category by its numeric ID, including its name and alias. Use this when you already know the category ID; to search or page through categories use centreon_host_category_list. Requires id and returns configuration only. Read-only.",
+		Annotations: readOnlyTool("Get host category"),
 	}, hostCategoryGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_category_create",
-		Description: "Create a new host category configuration.",
+		Description: "Define a new host category, a label for classifying hosts, with a name and optional alias. Use this to add a classification; to rename an existing category use centreon_host_category_update, and to remove one use centreon_host_category_delete. Requires name, and the new category stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: createTool("Create host category"),
 	}, hostCategoryCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_category_update",
-		Description: "Replace an existing host category configuration (full update).",
+		Description: "Overwrite the name and alias of an existing host category identified by its numeric ID. Use this to relabel a category added with centreon_host_category_create; to create a category use centreon_host_category_create and to remove one use centreon_host_category_delete. Requires id and name, replaces both fields, and the change stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: updateTool("Update host category"),
 	}, hostCategoryUpdateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_category_delete",
-		Description: "Delete a host category configuration by ID.",
+		Description: "Remove a host category by its numeric ID, unassigning that label from any hosts that carried it. Use this to drop an unused classification; to rename it instead use centreon_host_category_update, and to inspect it first use centreon_host_category_get. Requires id, and the deletion stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: deleteTool("Delete host category"),
 	}, hostCategoryDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_severity_list",
-		Description: "List host severity configurations. Supports pagination and name filtering.",
+		Description: "Retrieve a paginated list of host severities, the ranked priority levels (each carrying a level value and an icon) that mark how critical a host is. Use this to discover severity IDs; for one severity's details by ID use centreon_host_severity_get. Supports page (default 1), limit (default 30, max 100), and name search, and returns stored configuration only. Read-only.",
+		Annotations: readOnlyTool("List host severities"),
 	}, hostSeverityListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_severity_get",
-		Description: "Get a single host severity configuration by ID.",
+		Description: "Fetch the stored configuration of a single host severity by its numeric ID, including its name, level, and icon. Use this when you already know the severity ID; to search or page through severities use centreon_host_severity_list. Requires id and returns configuration only. Read-only.",
+		Annotations: readOnlyTool("Get host severity"),
 	}, hostSeverityGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_severity_create",
-		Description: "Create a new host severity configuration.",
+		Description: "Define a new host severity, a priority tier with a name, a numeric level where lower is more severe, and an icon. Use this to add a ranking tier; to change an existing severity use centreon_host_severity_update, and to remove one use centreon_host_severity_delete. Requires name, level, and iconID, and the new severity stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: createTool("Create host severity"),
 	}, hostSeverityCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_severity_update",
-		Description: "Replace an existing host severity configuration (full update).",
+		Description: "Overwrite the name, alias, level, and icon of an existing host severity identified by its numeric ID. Use this to re-rank a severity added with centreon_host_severity_create; to create a severity use centreon_host_severity_create and to remove one use centreon_host_severity_delete. Requires id, name, level, and iconID, replaces those fields, and the change stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: updateTool("Update host severity"),
 	}, hostSeverityUpdateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_severity_delete",
-		Description: "Delete a host severity configuration by ID.",
+		Description: "Remove a host severity by its numeric ID, clearing that priority tier from any hosts assigned to it. Use this to drop an unused tier; to re-rank it instead use centreon_host_severity_update, and to inspect it first use centreon_host_severity_get. Requires id, and the deletion stays configuration-only until pushed live with centreon_poller_apply. Writes to Centreon.",
+		Annotations: deleteTool("Delete host severity"),
 	}, hostSeverityDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_host_template_list",
-		Description: "List host template configurations. Supports pagination and name filtering.",
+		Description: "Retrieve a paginated list of host templates, the reusable blueprints that hosts inherit checks, macros, and settings from. Use this to find template IDs to pass in the templates field of centreon_host_create; this server exposes host templates as a read-only listing with no get, create, update, or delete counterpart. Supports page (default 1), limit (default 30, max 100), and name search, and returns stored configuration only. Read-only.",
+		Annotations: readOnlyTool("List host templates"),
 	}, hostTemplateListHandler(client, logger))
 }
 
@@ -126,14 +147,14 @@ type MacroInput struct {
 
 // CreateHostInput is the input for the centreon_host_create tool.
 type CreateHostInput struct {
-	MonitoringServerID int    `json:"monitoringServerID"         jsonschema:"Monitoring server ID"`
-	Name               string `json:"name"                       jsonschema:"Host name"`
-	Address            string `json:"address"                    jsonschema:"Host IP address or FQDN"`
-	Alias              string `json:"alias,omitempty"            jsonschema:"Host alias"`
-	CheckCommandID     int    `json:"checkCommandID,omitempty"   jsonschema:"Check command ID"`
-	Templates          []int  `json:"templates,omitempty"        jsonschema:"Host template IDs to inherit services and config from"`
-	Groups             []int  `json:"groups,omitempty"           jsonschema:"Host group IDs"`
-	Categories         []int  `json:"categories,omitempty"       jsonschema:"Host category IDs"`
+	MonitoringServerID int          `json:"monitoringServerID"         jsonschema:"Monitoring server ID"`
+	Name               string       `json:"name"                       jsonschema:"Host name"`
+	Address            string       `json:"address"                    jsonschema:"Host IP address or FQDN"`
+	Alias              string       `json:"alias,omitempty"            jsonschema:"Host alias"`
+	CheckCommandID     int          `json:"checkCommandID,omitempty"   jsonschema:"Check command ID"`
+	Templates          []int        `json:"templates,omitempty"        jsonschema:"Host template IDs to inherit services and config from"`
+	Groups             []int        `json:"groups,omitempty"           jsonschema:"Host group IDs"`
+	Categories         []int        `json:"categories,omitempty"       jsonschema:"Host category IDs"`
 	Macros             []MacroInput `json:"macros,omitempty"     jsonschema:"Custom macros"`
 }
 

--- a/tools/infra_tools.go
+++ b/tools/infra_tools.go
@@ -12,47 +12,56 @@ import (
 func RegisterInfraTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_server_list",
-		Description: "List monitoring servers (pollers). Supports pagination and name filtering.",
+		Description: "Retrieve the monitoring servers (pollers) that run checks and collect results across the Centreon platform, each with its identifier and configuration state. Use this to discover poller IDs before pushing stored configuration to one with centreon_poller_apply; it does not return check commands (centreon_command_list) or time periods (centreon_time_period_list). Supports name search and pagination (page 1, limit 30, max 100). Read-only.",
+		Annotations: readOnlyTool("List monitoring servers"),
 	}, serverListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_command_list",
-		Description: "List check commands. Supports pagination and name filtering.",
+		Description: "Retrieve the command definitions (checks, notifications, and other plugin invocations) that hosts and services reference to run their monitoring plugins. Use this to find command names and IDs when configuring monitoring; unlike centreon_server_list (pollers) or centreon_time_period_list (schedules), these are the executable command templates. Supports name search and pagination (page 1, limit 30, max 100). Read-only.",
+		Annotations: readOnlyTool("List commands"),
 	}, commandListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_time_period_list",
-		Description: "List time period configurations. Supports pagination and name filtering.",
+		Description: "Retrieve the time period definitions that control when checks run and notifications are sent, such as 24x7 or workhours schedules. Use this to find time period IDs, then centreon_time_period_get for the full weekday range detail of one; these are schedules, distinct from pollers (centreon_server_list) and commands (centreon_command_list). Supports name search and pagination (page 1, limit 30, max 100). Read-only.",
+		Annotations: readOnlyTool("List time periods"),
 	}, timePeriodListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_time_period_get",
-		Description: "Get a single time period configuration by ID.",
+		Description: "Fetch one time period by its numeric id, returning its name, alias, and full set of weekday time ranges. Use this once you have an id from centreon_time_period_list and need the complete schedule detail rather than a summary row. Requires the id parameter. Read-only.",
+		Annotations: readOnlyTool("Get time period"),
 	}, timePeriodGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_time_period_create",
-		Description: "Create a new time period configuration.",
+		Description: "Define a new time period from a name and a list of weekday time ranges (alias optional), returning the new numeric id. Use this to add a schedule; to change one that already exists use centreon_time_period_update, and to review current schedules first use centreon_time_period_list. Run centreon_poller_apply afterward to push the configuration live. Writes to Centreon.",
+		Annotations: createTool("Create time period"),
 	}, timePeriodCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_time_period_update",
-		Description: "Replace an existing time period configuration (full update).",
+		Description: "Replace the time period identified by id with the supplied name, alias, weekday ranges, and inherited templates as a full overwrite (omitted optional fields are cleared). Use this to change a schedule that already exists; to add a brand-new one use centreon_time_period_create. Run centreon_poller_apply afterward to push the configuration live. Writes to Centreon.",
+		Annotations: updateTool("Update time period"),
 	}, timePeriodUpdateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_time_period_delete",
-		Description: "Delete a time period configuration by ID.",
+		Description: "Permanently remove the time period with the given id from the stored configuration. Use this to retire a schedule; to change it in place instead use centreon_time_period_update. Requires the id parameter; run centreon_poller_apply afterward to push the change live. Writes to Centreon.",
+		Annotations: deleteTool("Delete time period"),
 	}, timePeriodDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_poller_apply",
-		Description: "Apply configuration (generate and reload) for a specific monitoring server (poller) by ID.",
+		Description: "Generate and reload the monitoring configuration for a single poller identified by pollerID, pushing stored config changes into the running engine and reloading that poller. Use this after create, update, or delete operations to make them take effect on one poller; to apply to every poller at once use centreon_poller_apply_all. Requires pollerID and may briefly reload the poller. Writes to Centreon.",
+		Annotations: updateTool("Apply poller config"),
 	}, pollerApplyHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_poller_apply_all",
-		Description: "Apply configuration (generate and reload) for all monitoring servers (pollers).",
+		Description: "Generate and reload the monitoring configuration for every poller on the platform, pushing all pending stored config changes into the running engines. Use this to activate configuration changes fleet-wide after edits; to target just one poller by id use centreon_poller_apply. Takes no arguments and may briefly reload each poller. Writes to Centreon.",
+		Annotations: updateTool("Apply all poller configs"),
 	}, pollerApplyAllHandler(client, logger))
 }
 
@@ -64,9 +73,9 @@ type TimePeriodDayInput struct {
 
 // CreateTimePeriodInput is the input for the centreon_time_period_create tool.
 type CreateTimePeriodInput struct {
-	Name      string               `json:"name"                jsonschema:"Time period name"`
-	Alias     string               `json:"alias,omitempty"     jsonschema:"Time period alias"`
-	Days []TimePeriodDayInput `json:"days" jsonschema:"Day definitions (required, use empty array [] if none)"`
+	Name  string               `json:"name"                jsonschema:"Time period name"`
+	Alias string               `json:"alias,omitempty"     jsonschema:"Time period alias"`
+	Days  []TimePeriodDayInput `json:"days" jsonschema:"Day definitions (required, use empty array [] if none)"`
 }
 
 // UpdateTimePeriodInput is the input for the centreon_time_period_update tool.

--- a/tools/monitoring_tools.go
+++ b/tools/monitoring_tools.go
@@ -12,52 +12,62 @@ import (
 func RegisterMonitoringTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_host_list",
-		Description: "List monitored hosts with real-time status. Supports pagination.",
+		Description: "Retrieve the real-time monitoring state of all hosts (current status, plugin output, acknowledgement, and downtime flags) as reported by the pollers. Use this for live health across many hosts; for one host by ID use centreon_monitoring_host_get, and for stored host configuration instead of live state use centreon_host_list. Reflects current engine state, not saved config; paginates with page (default 1) and limit (default 30, max 100). Read-only.",
+		Annotations: readOnlyTool("List monitoring hosts"),
 	}, monitoringHostListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_host_get",
-		Description: "Get a single monitored host by ID with real-time status details.",
+		Description: "Fetch the real-time monitoring state of one host by its numeric monitoring ID, including current status, last check, plugin output, and active problem flags. Use this when you already know the host ID; to browse or page through many hosts use centreon_monitoring_host_list, and for the alternative unified resource view use centreon_monitoring_resource_host_get. Requires id; returns live engine state rather than stored configuration. Read-only.",
+		Annotations: readOnlyTool("Get monitoring host"),
 	}, monitoringHostGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_host_services",
-		Description: "List all services for a specific monitored host.",
+		Description: "List the real-time monitoring state of every service attached to one host, given its hostID. Use this to see all checks on a single host; to list services across all hosts use centreon_monitoring_service_list, and to fetch one specific service use centreon_monitoring_resource_service_get. Requires hostID; paginates with page (default 1) and limit (default 30, max 100) and reflects current engine state, not stored config. Read-only.",
+		Annotations: readOnlyTool("List host services"),
 	}, monitoringHostServicesHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_host_timeline",
-		Description: "Get timeline events for a specific monitored host.",
+		Description: "Retrieve the chronological event history for one host (state changes, notifications, acknowledgements, downtime, and comments) given its hostID. Use this to investigate what happened over time; for the current point-in-time snapshot instead use centreon_monitoring_host_get. Requires hostID; paginates with page (default 1) and limit (default 30, max 100) over live monitoring events. Read-only.",
+		Annotations: readOnlyTool("Get host timeline"),
 	}, monitoringHostTimelineHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_host_status_counts",
-		Description: "Get host counts by state (up, down, unreachable, pending).",
+		Description: "Summarize how many hosts are currently in each monitoring state (up, down, unreachable, pending) as a single aggregate, taking no arguments. Use this for a quick host health total; for the per-host detail behind the numbers use centreon_monitoring_host_list, and for hosts plus services plus servers in one call use centreon_platform_status. Reflects current engine state, not stored configuration. Read-only.",
+		Annotations: readOnlyTool("Host status counts"),
 	}, monitoringHostStatusCountsHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_service_list",
-		Description: "List monitored services with real-time status. Supports pagination.",
+		Description: "Retrieve the real-time monitoring state of all services across every host (current status, plugin output, acknowledgement, and downtime flags). Use this for live health across many services; to limit to one host's services use centreon_monitoring_host_services, and for stored service configuration instead of live state use centreon_service_list. Paginates with page (default 1) and limit (default 30, max 100) and reflects current engine state, not saved config. Read-only.",
+		Annotations: readOnlyTool("List monitoring services"),
 	}, monitoringServiceListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_service_status_counts",
-		Description: "Get service counts by state (ok, warning, critical, unknown, pending).",
+		Description: "Summarize how many services are currently in each monitoring state (ok, warning, critical, unknown, pending) as a single aggregate, taking no arguments. Use this for a quick service health total; for the host-side equivalent use centreon_monitoring_host_status_counts, and for the per-service detail behind the numbers use centreon_monitoring_service_list. Reflects current engine state, not stored configuration. Read-only.",
+		Annotations: readOnlyTool("Service status counts"),
 	}, monitoringServiceStatusCountsHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_resource_list",
-		Description: "List all monitored resources (hosts and services) in a unified view. Supports pagination.",
+		Description: "List hosts and services together in Centreon's unified resource view, each with its real-time monitoring status. Use this when you want hosts and services in one combined stream; for only hosts use centreon_monitoring_host_list and for only services use centreon_monitoring_service_list. Paginates with page (default 1) and limit (default 30, max 100) and reflects current engine state, not stored configuration. Read-only.",
+		Annotations: readOnlyTool("List monitoring resources"),
 	}, monitoringResourceListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_resource_host_get",
-		Description: "Get a single host via the unified monitoring resource API.",
+		Description: "Fetch one host's real-time monitoring status through Centreon's unified resource API, given its numeric id. Use this for the resource-view representation of a host; for the host-endpoint representation of the same live state use centreon_monitoring_host_get. Requires id; returns live engine state rather than stored configuration. Read-only.",
+		Annotations: readOnlyTool("Get resource host"),
 	}, monitoringResourceHostGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_resource_service_get",
-		Description: "Get a single service via the unified monitoring resource API. This is the only way to get a single monitoring service by ID.",
+		Description: "Fetch one service's real-time monitoring status through Centreon's unified resource API, given both its hostID and serviceID. This is the only tool that returns a single monitoring service by ID; to list services instead use centreon_monitoring_service_list or, scoped to one host, centreon_monitoring_host_services. Requires hostID and serviceID; returns live engine state rather than stored configuration. Read-only.",
+		Annotations: readOnlyTool("Get resource service"),
 	}, monitoringResourceServiceGetHandler(client, logger))
 }
 

--- a/tools/notification_tools.go
+++ b/tools/notification_tools.go
@@ -12,12 +12,14 @@ import (
 func RegisterNotificationTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_notification_policy_host_get",
-		Description: "Get the notification policy for a specific host.",
+		Description: "Fetch the configured notification policy for one host identified by its numeric hostID, reporting whether notifications are enabled and which users and contact groups receive them. Use this for a host; for a specific service on that host use centreon_notification_policy_service_get, and to resolve the referenced recipients use centreon_user_list or centreon_contact_group_list. Reads stored configuration, not live monitoring state. Read-only.",
+		Annotations: readOnlyTool("Get host notification policy"),
 	}, notificationPolicyHostGetHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_notification_policy_service_get",
-		Description: "Get the notification policy for a specific service on a host.",
+		Description: "Fetch the configured notification policy for one service, identified by both its numeric hostID and serviceID, reporting whether notifications are enabled and which users and contact groups receive them. Use this for a service; for the host-level policy use centreon_notification_policy_host_get, and to resolve the referenced recipients use centreon_user_list or centreon_contact_group_list. Reads stored configuration, not live monitoring state. Read-only.",
+		Annotations: readOnlyTool("Get service notification policy"),
 	}, notificationPolicyServiceGetHandler(client, logger))
 }
 

--- a/tools/operations_tools.go
+++ b/tools/operations_tools.go
@@ -13,27 +13,32 @@ import (
 func RegisterOperationsTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_resource_acknowledge",
-		Description: "Acknowledge a host or service resource to suppress notifications.",
+		Description: "Acknowledge an active problem on a monitored host or service so Centreon stops repeat notifications while someone investigates, identifying the resource by type (host or service) and id, plus the parent host id for a service, and attaching a required comment. Use this for an ongoing incident; use centreon_resource_downtime to silence a resource during planned maintenance, or centreon_resource_comment to annotate without suppressing notifications. Optional flags keep the acknowledgement sticky until recovery, notify contacts, and persist the comment; clear it later with centreon_acknowledgement_host_cancel or centreon_acknowledgement_service_cancel. Writes to Centreon.",
+		Annotations: createTool("Acknowledge resource"),
 	}, bulkAcknowledgeHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_resource_downtime",
-		Description: "Schedule downtime for a host or service resource.",
+		Description: "Schedule a maintenance downtime window on a monitored host or service to suppress its alerts and notifications between an RFC3339 start and end time, identifying the resource by type (host or service) and id, plus the parent host id for a service. Use this for planned maintenance; use centreon_resource_acknowledge to silence an unplanned problem that is already active. Fixed downtime covers the whole window while flexible downtime starts on the first problem and runs for the given duration; cancel it with centreon_downtime_host_cancel or centreon_downtime_service_cancel. Writes to Centreon.",
+		Annotations: createTool("Schedule resource downtime"),
 	}, bulkDowntimeHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_resource_check",
-		Description: "Force an immediate check for a host or service resource.",
+		Description: "Force the monitoring engine to run an active check of a host or service right now instead of waiting for its next scheduled check, identifying the resource by type (host or service) and id, plus the parent host id for a service. Use this to refresh state on demand after a suspected recovery; use centreon_resource_submit instead to push an externally computed result rather than triggering the engine's own check. The check runs asynchronously and updates the resource's live status and output once it completes. Writes to Centreon.",
+		Annotations: createTool("Force resource check"),
 	}, bulkCheckHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_resource_submit",
-		Description: "Submit a passive check result for a host or service resource.",
+		Description: "Submit a passive check result for a host or service, setting its status (0=OK/UP, 1=WARNING/DOWN, 2=CRITICAL/UNREACHABLE, 3=UNKNOWN) with an output message and optional performance data, identifying the resource by type (host or service) and id, plus the parent host id for a service. Use this to report a result computed outside Centreon; use centreon_resource_check instead to make the engine run its own active check. The submitted status and output immediately replace the resource's live state without the engine re-checking it. Writes to Centreon.",
+		Annotations: createTool("Submit check result"),
 	}, bulkSubmitHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_resource_comment",
-		Description: "Add a comment to a host or service resource.",
+		Description: "Attach a free-text comment to a monitored host or service to record context for operators, identifying the resource by type (host or service) and id, plus the parent host id for a service. Use this to annotate a resource without changing its state; use centreon_resource_acknowledge instead when you also want to suppress notifications for an active problem. The comment appears in the resource timeline and does not affect checks or alerting. Writes to Centreon.",
+		Annotations: createTool("Comment on resource"),
 	}, bulkCommentHandler(client, logger))
 }
 

--- a/tools/service_config_tools.go
+++ b/tools/service_config_tools.go
@@ -12,82 +12,98 @@ import (
 func RegisterServiceConfigTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_list",
-		Description: "List service configurations. Supports pagination and name filtering.",
+		Description: "Retrieve stored service configuration records across all hosts, with optional name search and pagination. Use this to inventory configured services; for live runtime status call centreon_monitoring_service_list instead, and to restrict the listing to one host use centreon_service_list_by_host. Returns page 1 with 30 results by default (maximum 100 per page) and reflects saved configuration only. Read-only.",
+		Annotations: readOnlyTool("List services"),
 	}, serviceListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_list_by_host",
-		Description: "List service configurations for a specific host. The services API does not support lookup by service ID; use this to find services by their parent host.",
+		Description: "List the stored service configurations attached to one host, identified by its hostID, with optional name search and pagination. Use this instead of centreon_service_list when you already know the parent host, and as the way to locate a specific service since the services configuration API cannot look one up by service ID. Returns page 1 with 30 results by default (maximum 100 per page) and reflects saved configuration, not live monitoring. Read-only.",
+		Annotations: readOnlyTool("List services by host"),
 	}, serviceListByHostHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_create",
-		Description: "Create a new service configuration.",
+		Description: "Add a new service configuration to a host, requiring the parent hostID and a service name, and optionally inheriting settings from a service template plus a check command, service groups, categories, and custom macros. Use this to define a service; to change an existing one call centreon_service_update, and to remove one call centreon_service_delete. The service is saved to configuration only and does not begin monitoring until centreon_poller_apply pushes the change to the pollers. Writes to Centreon.",
+		Annotations: createTool("Create service"),
 	}, serviceCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_update",
-		Description: "Update an existing service configuration (partial update).",
+		Description: "Modify selected fields of an existing service configuration identified by its id, such as name, check command, check intervals, active-check mode, or activation, leaving unspecified fields unchanged. Use this to adjust a service already created with centreon_service_create; to add a new one use that tool and to remove one use centreon_service_delete. This is a partial update saved to configuration only, taking effect after centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: updateTool("Update service"),
 	}, serviceUpdateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_delete",
-		Description: "Delete a service configuration by ID.",
+		Description: "Permanently remove a service configuration identified by its id. Use this to delete a service defined with centreon_service_create; to change one without removing it use centreon_service_update instead. The deletion is applied to configuration only and takes effect once centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: deleteTool("Delete service"),
 	}, serviceDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_group_list",
-		Description: "List service group configurations. Supports pagination and name filtering.",
+		Description: "List stored service group configurations, the named collections that bundle services together, with optional name search and pagination. Use this rather than centreon_service_list, which returns individual services; create a group with centreon_service_group_create and remove one with centreon_service_group_delete. Returns page 1 with 30 results by default (maximum 100 per page) and reflects saved configuration only. Read-only.",
+		Annotations: readOnlyTool("List service groups"),
 	}, serviceGroupListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_group_create",
-		Description: "Create a new service group configuration.",
+		Description: "Define a new service group, a named collection of services, requiring a group name and accepting an optional alias. Use this for grouping rather than centreon_service_create, which defines an individual service; list existing groups with centreon_service_group_list and remove one with centreon_service_group_delete. The group is saved to configuration only and takes effect after centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: createTool("Create service group"),
 	}, serviceGroupCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_group_delete",
-		Description: "Delete a service group configuration by ID.",
+		Description: "Remove a service group configuration identified by its id, deleting the grouping without affecting the member services themselves. Use this to undo a group created with centreon_service_group_create; to review existing groups first call centreon_service_group_list. The deletion is saved to configuration only and takes effect once centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: deleteTool("Delete service group"),
 	}, serviceGroupDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_category_list",
-		Description: "List service category configurations. Supports pagination and name filtering.",
+		Description: "List stored service category configurations, the labels used to classify services for filtering and reporting, with optional name search and pagination. Use this rather than centreon_service_group_list, which returns groupings of services; create a category with centreon_service_category_create and remove one with centreon_service_category_delete. Returns page 1 with 30 results by default (maximum 100 per page) and reflects saved configuration only. Read-only.",
+		Annotations: readOnlyTool("List service categories"),
 	}, serviceCategoryListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_category_create",
-		Description: "Create a new service category configuration.",
+		Description: "Define a new service category, a classification label applied to services, requiring a category name and accepting an optional alias. Use this for classification rather than centreon_service_group_create, which builds a collection of services; list existing categories with centreon_service_category_list and remove one with centreon_service_category_delete. The category is saved to configuration only and takes effect after centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: createTool("Create service category"),
 	}, serviceCategoryCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_category_delete",
-		Description: "Delete a service category configuration by ID.",
+		Description: "Remove a service category configuration identified by its id, deleting the classification label without affecting the services that carried it. Use this to undo a category created with centreon_service_category_create; to review existing categories first call centreon_service_category_list. The deletion is saved to configuration only and takes effect once centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: deleteTool("Delete service category"),
 	}, serviceCategoryDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_severity_list",
-		Description: "List service severity configurations. Supports pagination and name filtering.",
+		Description: "List stored service severity configurations, the prioritization levels that rank how critical a service is, with optional name search and pagination. Use this rather than centreon_service_category_list, which returns classification labels; create a severity with centreon_service_severity_create, change one with centreon_service_severity_update, and remove one with centreon_service_severity_delete. Returns page 1 with 30 results by default (maximum 100 per page) and reflects saved configuration only. Read-only.",
+		Annotations: readOnlyTool("List service severities"),
 	}, serviceSeverityListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_severity_create",
-		Description: "Create a new service severity configuration.",
+		Description: "Define a new service severity, a prioritization level for ranking services, requiring a name, a numeric level where a lower number is more severe, and an icon id, with an optional alias. Use this to add a severity; to overwrite an existing one call centreon_service_severity_update, and to remove one call centreon_service_severity_delete. The severity is saved to configuration only and takes effect after centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: createTool("Create service severity"),
 	}, serviceSeverityCreateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_severity_update",
-		Description: "Replace an existing service severity configuration (full update).",
+		Description: "Overwrite an existing service severity identified by its id, replacing its name, numeric level (lower is more severe), icon id, and optional alias as a full update that sets every field, so supply all intended values. Use this to change a severity created with centreon_service_severity_create; to remove one instead call centreon_service_severity_delete. The change is saved to configuration only and takes effect after centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: updateTool("Update service severity"),
 	}, serviceSeverityUpdateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_severity_delete",
-		Description: "Delete a service severity configuration by ID.",
+		Description: "Remove a service severity configuration identified by its id, deleting the prioritization level from the platform. Use this to undo a severity created with centreon_service_severity_create; to change one instead call centreon_service_severity_update. The deletion is saved to configuration only and takes effect once centreon_poller_apply pushes it to the pollers. Writes to Centreon.",
+		Annotations: deleteTool("Delete service severity"),
 	}, serviceSeverityDeleteHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_service_template_list",
-		Description: "List service template configurations. Supports pagination and name filtering.",
+		Description: "List stored service template configurations, the reusable presets that new services inherit their settings from, with optional name search and pagination. Use this to find a template id to pass to centreon_service_create; for actual services rather than their templates use centreon_service_list. Returns page 1 with 30 results by default (maximum 100 per page) and reflects saved configuration only. Read-only.",
+		Annotations: readOnlyTool("List service templates"),
 	}, serviceTemplateListHandler(client, logger))
 }
 

--- a/tools/status_tools.go
+++ b/tools/status_tools.go
@@ -10,16 +10,17 @@ import (
 
 // PlatformStatus combines host status counts, service status counts, and monitoring servers.
 type PlatformStatus struct {
-	Hosts    *centreon.HostStatusCount                              `json:"hosts"`
-	Services *centreon.ServiceStatusCount                           `json:"services"`
-	Servers  *centreon.ListResponse[centreon.MonitoringServer]      `json:"servers"`
+	Hosts    *centreon.HostStatusCount                         `json:"hosts"`
+	Services *centreon.ServiceStatusCount                      `json:"services"`
+	Servers  *centreon.ListResponse[centreon.MonitoringServer] `json:"servers"`
 }
 
 // RegisterStatusTools registers all platform status tools.
 func RegisterStatusTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_platform_status",
-		Description: "Get a combined platform overview: host status counts, service status counts, and monitoring servers.",
+		Description: "Return a combined live platform overview in one call: host status counts (up/down/unreachable), service status counts (ok/warning/critical/unknown), and the list of monitoring servers. Use this for an at-a-glance health snapshot; for the individual pieces use centreon_monitoring_host_status_counts, centreon_monitoring_service_status_counts, or centreon_server_list. Read-only.",
+		Annotations: readOnlyTool("Platform status"),
 	}, platformStatusHandler(client, logger))
 }
 

--- a/tools/tdqs_test.go
+++ b/tools/tdqs_test.go
@@ -1,0 +1,91 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	centreon "github.com/tphakala/centreon-go-client"
+)
+
+// checkToolTDQS asserts the tier-A invariants for one tool: a substantive
+// description, annotations carrying a title, no em or en dashes, and a trailing
+// read/write marker consistent with the readOnly hint (so the description never
+// contradicts the annotation, a TDQS hard-gate failure).
+func checkToolTDQS(t *testing.T, tool *mcp.Tool) {
+	t.Helper()
+	const (
+		minDescLen      = 40
+		emDash     rune = 0x2014
+		enDash     rune = 0x2013
+	)
+	name := tool.Name
+
+	if len(strings.TrimSpace(tool.Description)) < minDescLen {
+		t.Errorf("%s: description too short to be specific: %q", name, tool.Description)
+	}
+	if tool.Annotations == nil {
+		t.Errorf("%s: missing annotations", name)
+		return
+	}
+	if strings.TrimSpace(tool.Annotations.Title) == "" {
+		t.Errorf("%s: missing annotation title", name)
+	}
+	for _, field := range []string{tool.Description, tool.Annotations.Title} {
+		if strings.ContainsRune(field, emDash) || strings.ContainsRune(field, enDash) {
+			t.Errorf("%s: contains em/en dash: %q", name, field)
+		}
+	}
+
+	readOnly := tool.Annotations.ReadOnlyHint
+	endsRead := strings.HasSuffix(tool.Description, "Read-only.")
+	endsWrite := strings.HasSuffix(tool.Description, "Writes to Centreon.")
+	switch {
+	case !endsRead && !endsWrite:
+		t.Errorf("%s: description missing Read-only./Writes to Centreon. marker", name)
+	case readOnly && endsWrite:
+		t.Errorf("%s: readOnly tool claims Writes to Centreon", name)
+	case !readOnly && endsRead:
+		t.Errorf("%s: write tool claims Read-only", name)
+	}
+}
+
+// TestTDQS_ToolDefinitionsQuality lists every registered tool over a real
+// in-memory MCP session (confirming annotations serialize end to end) and
+// checks the tier-A invariants on each. A zero-value client is enough because
+// registration only binds handler method values; tools/list never calls them.
+func TestTDQS_ToolDefinitionsQuality(t *testing.T) {
+	const wantTools = 88
+
+	ctx := t.Context()
+
+	s := mcp.NewServer(&mcp.Implementation{Name: "centreon-mcp-go", Version: "test"}, nil)
+	RegisterAll(s, &centreon.Client{}, nil)
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	ss, err := s.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "tdqs-test", Version: "0"}, nil)
+	cs, err := c.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	count := 0
+	for tool, iterErr := range cs.Tools(ctx, nil) {
+		if iterErr != nil {
+			t.Fatalf("listing tools: %v", iterErr)
+		}
+		count++
+		checkToolTDQS(t, tool)
+	}
+
+	if count < wantTools {
+		t.Errorf("expected at least %d registered tools, got %d", wantTools, count)
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -33,6 +33,27 @@ func RegisterAll(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	RegisterConnectionTools(s, client, logger)
 }
 
+// readOnlyTool annotates a tool that only reads from the Centreon API (open world).
+// DestructiveHint is set false explicitly (redundant under ReadOnlyHint, but unambiguous for scanners).
+func readOnlyTool(title string) *mcp.ToolAnnotations {
+	return &mcp.ToolAnnotations{Title: title, ReadOnlyHint: true, DestructiveHint: new(false), OpenWorldHint: new(true)}
+}
+
+// createTool annotates a tool that additively creates a record or submits an additive action.
+func createTool(title string) *mcp.ToolAnnotations {
+	return &mcp.ToolAnnotations{Title: title, DestructiveHint: new(false), IdempotentHint: false, OpenWorldHint: new(true)}
+}
+
+// updateTool annotates a tool that overwrites an existing record or applies configuration changes.
+func updateTool(title string) *mcp.ToolAnnotations {
+	return &mcp.ToolAnnotations{Title: title, DestructiveHint: new(true), IdempotentHint: true, OpenWorldHint: new(true)}
+}
+
+// deleteTool annotates a tool that deletes a record or cancels a scheduled action.
+func deleteTool(title string) *mcp.ToolAnnotations {
+	return &mcp.ToolAnnotations{Title: title, DestructiveHint: new(true), IdempotentHint: true, OpenWorldHint: new(true)}
+}
+
 // ListInput is the common input for list tools.
 type ListInput struct {
 	Page   int    `json:"page,omitempty"   jsonschema:"Page number (default 1)"`

--- a/tools/user_tools.go
+++ b/tools/user_tools.go
@@ -12,32 +12,38 @@ import (
 func RegisterUserTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_user_list",
-		Description: "List users (contacts). Supports pagination and name filtering.",
+		Description: "Retrieve Centreon users (contacts), returning each user's id, name, alias, email, admin flag, and activation state, with an optional name search. To change a user's name, alias, or email use centreon_user_update; for the related grouping and template objects use centreon_contact_group_list or centreon_contact_template_list. Defaults to page 1 with 30 results per page (max 100) and matches the search term as a name substring. Read-only.",
+		Annotations: readOnlyTool("List users"),
 	}, userListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_user_update",
-		Description: "Update an existing user (partial update via PATCH).",
+		Description: "Apply a partial update to one existing user (contact) identified by its numeric id, changing only the name, alias, or email fields you supply and leaving the rest untouched. Use this after locating the target with centreon_user_list; to save user-scoped resource filters instead use centreon_user_filter_create. Sends a PATCH, so omitted fields are preserved, and reports the updated user id. Writes to Centreon.",
+		Annotations: updateTool("Update user"),
 	}, userUpdateHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_contact_group_list",
-		Description: "List contact groups. Supports pagination and name filtering.",
+		Description: "List Centreon contact groups, the named collections of users used as notification recipients, with an optional name search. Use this to discover contact group names and ids that appear in notification policies from centreon_notification_policy_host_get; for the individual members use centreon_user_list. Defaults to page 1 with 30 results per page (max 100) and matches the search term as a name substring. Read-only.",
+		Annotations: readOnlyTool("List contact groups"),
 	}, contactGroupListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_contact_template_list",
-		Description: "List contact templates. Supports pagination and name filtering.",
+		Description: "List Centreon contact templates, the reusable configuration presets that users (contacts) inherit their settings from, with an optional name search. Use this to find template names and ids that describe contact defaults; for concrete users use centreon_user_list and for user groupings use centreon_contact_group_list. Defaults to page 1 with 30 results per page (max 100) and matches the search term as a name substring. Read-only.",
+		Annotations: readOnlyTool("List contact templates"),
 	}, contactTemplateListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_user_filter_list",
-		Description: "List user filters. Supports pagination and name filtering.",
+		Description: "List saved user filters, the named sets of resource-status search criteria stored per user, returning each filter's id, name, and criteria, with an optional name search. Use this to review or find an existing filter before saving a new one with centreon_user_filter_create. Defaults to page 1 with 30 results per page (max 100) and matches the search term as a name substring. Read-only.",
+		Annotations: readOnlyTool("List user filters"),
 	}, userFilterListHandler(client, logger))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_user_filter_create",
-		Description: "Create a new user filter.",
+		Description: "Save a new user filter from a required name and an optional list of resource-status criteria, returning the new filter's numeric id. Use this to persist a reusable filter; to review existing filters first call centreon_user_filter_list, and to edit users themselves use centreon_user_update. Adds a new record without altering existing filters. Writes to Centreon.",
+		Annotations: createTool("Create user filter"),
 	}, userFilterCreateHandler(client, logger))
 }
 


### PR DESCRIPTION
Reworks all 88 MCP tool definitions to raise their Glama [Tool Definition Quality Score](https://github.com/glama-ai/tool-definition-quality-score) (TDQS) to tier A, ahead of listing the server on glama.ai and awesome-mcp-servers. No handler behavior, tool names, or input schemas change: this is a metadata-quality change.

## What changed

- **MCP annotations on all 88 tools.** Four helper constructors in `tools/tools.go` set `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, and a title. Classified by MCP semantics: monitoring/status/list/get reads and notification-policy lookups are read-only; create plus additive actions (acknowledge, downtime, check, submit, comment, user-filter create) are additive; update plus `poller_apply`/`poller_apply_all` are destructive and idempotent; delete and cancel are destructive deletes. Uses Go 1.26 `new(true)`/`new(false)` as the repo's `NewWithExpression` ruleguard rule endorses.
- **Rewritten descriptions.** Every description now states a specific purpose, when to use the tool versus its named sibling, and its real behavior, including the monitoring-versus-configuration distinction (config edits need `centreon_poller_apply` to take effect) and pagination defaults. Clears the TDQS tautology and annotation-contradiction hard gates.
- **New regression test** `TestTDQS_ToolDefinitionsQuality` lists every tool over an in-memory MCP session and asserts each keeps a substantive description, a titled annotation, a read/write marker consistent with its `readOnlyHint`, and no em/en dashes.
- **Docs cleanup** (README, BUG_REPORT).

## Verification

`go build`, `go vet`, `golangci-lint run` (0 issues), and `go test ./...` all green. Automated checks confirmed 88/88 annotation coverage, zero hallucinated sibling references, and marker-vs-annotation consistency. Two independent peer reviews cross-checked annotation semantics and descriptions against the handler code (required fields, pagination defaults, poller-apply and cancel-all semantics) with no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for Centreon tools, including inputs, outputs, pagination, filtering, read-only behavior, and write operations.
  * Clarified connection testing and acknowledgement, downtime, monitoring, configuration, notification, operations, status, and user-management workflows.
  * Improved README formatting, configuration defaults, usage instructions, and development command descriptions.
  * Updated bug-report references and formatting for clarity.

* **Quality**
  * Added validation ensuring registered tools provide complete descriptions and consistent operation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->