### PR TITLE
feat: add optional host allowlist for gateway mode (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ MCP_HTTP_PORT=8080
 MCP_HTTP_HOST=0.0.0.0
 AUTH_MODE=env
 LOG_LEVEL=info
+
+# Optional: gateway mode host allowlist (comma-separated).
+# When set, only these X-Centreon-Host values are accepted; unset allows any host.
+# CENTREON_ALLOWED_HOSTS=https://centreon.example.com,https://centreon2.example.com

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ All configuration is via environment variables.
 | `MCP_HTTP_PORT`             | No       | `8080`      | HTTP listen port (HTTP transport only)                       |
 | `MCP_HTTP_HOST`             | No       | `0.0.0.0`   | HTTP listen address (HTTP transport only)                    |
 | `AUTH_MODE`                 | No       | `env`       | Authentication mode: `env` or `gateway`                      |
+| `CENTREON_ALLOWED_HOSTS`    | No       | (none)      | Gateway mode only: comma-separated allowlist of accepted `X-Centreon-Host` values. Unset or empty means any host is accepted. |
 | `LOG_LEVEL`                 | No       | `info`      | Log level: `debug`, `info`, `warn`, or `error`               |
 
 \* Either `CENTREON_TOKEN` or both `CENTREON_USERNAME` and `CENTREON_PASSWORD` must be set. In `gateway` auth mode, credentials are supplied per-request via headers instead.
@@ -160,11 +161,20 @@ Enable it with `AUTH_MODE=gateway` alongside `MCP_TRANSPORT=http`. In this mode,
 
 Acquired session tokens are cached for 50 minutes per (host, username) pair to avoid repeated logins.
 
-**Note:** Deploy behind a reverse proxy (nginx, Caddy, Traefik, etc.) in production. Do not expose gateway mode directly to untrusted clients, as it accepts arbitrary Centreon credentials.
+### Host allowlist
+
+By default gateway mode connects to whatever `X-Centreon-Host` a caller supplies, so an exposed endpoint can be used as an SSRF or open-proxy primitive. Set `CENTREON_ALLOWED_HOSTS` to a comma-separated list of permitted host URLs to restrict this; requests whose `X-Centreon-Host` does not match an entry exactly are rejected. When the variable is unset or empty, behavior is unchanged (any host is accepted) and the server logs a warning at startup. Matching is exact and case-sensitive, so list each host URL as callers send it.
+
+```bash
+export CENTREON_ALLOWED_HOSTS="https://centreon.example.com,https://centreon2.example.com"
+```
+
+**Note:** Deploy behind a reverse proxy (nginx, Caddy, Traefik, etc.) in production. Do not expose gateway mode directly to untrusted clients, as it accepts arbitrary Centreon credentials. Set `CENTREON_ALLOWED_HOSTS` to limit which Centreon servers the gateway will connect to.
 
 ```bash
 export MCP_TRANSPORT=http
 export AUTH_MODE=gateway
+export CENTREON_ALLOWED_HOSTS="https://centreon.example.com"
 ./centreon-mcp-go
 ```
 

--- a/config.go
+++ b/config.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
+
+// defaultHTTPPort is the listen port used when MCP_HTTP_PORT is unset.
+const defaultHTTPPort = 8080
 
 // Config holds the server configuration.
 type Config struct {
@@ -18,6 +22,9 @@ type Config struct {
 	HTTPHost        string
 	AuthMode        string
 	LogLevel        string
+	// AllowedHosts restricts the X-Centreon-Host header in gateway mode.
+	// Empty means no restriction (any host accepted).
+	AllowedHosts []string
 }
 
 // LoadConfig reads configuration from environment variables.
@@ -64,20 +71,11 @@ func LoadConfig() (Config, error) {
 		cfg.HTTPHost = "0.0.0.0"
 	}
 
-	portStr := os.Getenv("MCP_HTTP_PORT")
-	if portStr != "" {
-		port, err := strconv.Atoi(portStr)
-		if err != nil {
-			return Config{}, fmt.Errorf("invalid MCP_HTTP_PORT value %q: %w", portStr, err)
-		}
-		if port < 1 || port > 65535 {
-			return Config{}, fmt.Errorf("MCP_HTTP_PORT must be between 1 and 65535, got %d", port)
-		}
-		cfg.HTTPPort = port
+	port, err := loadHTTPPort()
+	if err != nil {
+		return Config{}, err
 	}
-	if cfg.HTTPPort == 0 {
-		cfg.HTTPPort = 8080
-	}
+	cfg.HTTPPort = port
 
 	selfSigned := os.Getenv("CENTREON_ALLOW_SELF_SIGNED")
 	if selfSigned != "" {
@@ -88,7 +86,59 @@ func LoadConfig() (Config, error) {
 		cfg.AllowSelfSigned = v
 	}
 
+	allowedHosts, err := loadAllowedHosts()
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.AllowedHosts = allowedHosts
+
 	return cfg, nil
+}
+
+// loadHTTPPort resolves the MCP_HTTP_PORT value, defaulting to 8080 when unset.
+func loadHTTPPort() (int, error) {
+	portStr := os.Getenv("MCP_HTTP_PORT")
+	if portStr == "" {
+		return defaultHTTPPort, nil
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid MCP_HTTP_PORT value %q: %w", portStr, err)
+	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("MCP_HTTP_PORT must be between 1 and 65535, got %d", port)
+	}
+	return port, nil
+}
+
+// loadAllowedHosts reads and parses the CENTREON_ALLOWED_HOSTS allowlist.
+// An unset or empty variable yields a nil slice (no restriction), matching
+// os.Getenv, which cannot distinguish the two. A variable set to a non-empty
+// value that has no valid entries after trimming (e.g. " , , ") is a
+// misconfiguration and returns an error.
+func loadAllowedHosts() ([]string, error) {
+	raw := os.Getenv("CENTREON_ALLOWED_HOSTS")
+	if raw == "" {
+		return nil, nil
+	}
+	hosts := parseAllowedHosts(raw)
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("CENTREON_ALLOWED_HOSTS is set but contains no valid host entries")
+	}
+	return hosts, nil
+}
+
+// parseAllowedHosts splits a comma-separated host list, trimming whitespace
+// and dropping empty entries.
+func parseAllowedHosts(raw string) []string {
+	parts := strings.Split(raw, ",")
+	hosts := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if h := strings.TrimSpace(p); h != "" {
+			hosts = append(hosts, h)
+		}
+	}
+	return hosts
 }
 
 func envOr(key, fallback string) string {

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"slices"
+	"strings"
+	"testing"
+)
 
 func TestLoadConfig_Valid(t *testing.T) {
 	t.Setenv("CENTREON_HOST", "https://centreon.example.com")
@@ -131,5 +135,102 @@ func TestLoadConfig_TokenOnly(t *testing.T) {
 	}
 	if cfg.Token != "my-api-token" {
 		t.Errorf("expected Token my-api-token, got %q", cfg.Token)
+	}
+}
+
+func TestLoadConfig_AllowedHosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    []string
+		wantErr bool
+	}{
+		{"unset or empty yields no allowlist", "", nil, false},
+		{"single host", "https://a.example.com", []string{"https://a.example.com"}, false},
+		{
+			"multiple hosts trimmed",
+			" https://a.example.com , https://b.example.com ",
+			[]string{"https://a.example.com", "https://b.example.com"},
+			false,
+		},
+		{"empty entries dropped", "https://a.example.com,,", []string{"https://a.example.com"}, false},
+		{"only separators and whitespace errors", " , , ", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CENTREON_HOST", "https://centreon.example.com")
+			t.Setenv("CENTREON_USERNAME", "admin")
+			t.Setenv("CENTREON_PASSWORD", "secret")
+			t.Setenv("CENTREON_TOKEN", "")
+			// Isolate from ambient values so the only error source is the allowlist.
+			t.Setenv("MCP_HTTP_PORT", "")
+			t.Setenv("MCP_TRANSPORT", "")
+			t.Setenv("AUTH_MODE", "")
+			t.Setenv("CENTREON_ALLOWED_HOSTS", tt.value)
+
+			cfg, err := LoadConfig()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "CENTREON_ALLOWED_HOSTS") {
+					t.Errorf("expected error about CENTREON_ALLOWED_HOSTS, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if !slices.Equal(cfg.AllowedHosts, tt.want) {
+				t.Errorf("expected AllowedHosts %v, got %v", tt.want, cfg.AllowedHosts)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_HTTPPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{"unset defaults to 8080", "", defaultHTTPPort, false},
+		{"valid port", "9090", 9090, false},
+		{"non-numeric errors", "abc", 0, true},
+		{"below range errors", "0", 0, true},
+		{"above range errors", "70000", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CENTREON_HOST", "https://centreon.example.com")
+			t.Setenv("CENTREON_TOKEN", "tok")
+			t.Setenv("CENTREON_USERNAME", "")
+			t.Setenv("CENTREON_PASSWORD", "")
+			// Isolate from ambient values so the only error source is the port.
+			t.Setenv("CENTREON_ALLOWED_HOSTS", "")
+			t.Setenv("MCP_TRANSPORT", "")
+			t.Setenv("AUTH_MODE", "")
+			t.Setenv("MCP_HTTP_PORT", tt.value)
+
+			cfg, err := LoadConfig()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "MCP_HTTP_PORT") {
+					t.Errorf("expected error about MCP_HTTP_PORT, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if cfg.HTTPPort != tt.want {
+				t.Errorf("HTTPPort = %d, want %d", cfg.HTTPPort, tt.want)
+			}
+		})
 	}
 }

--- a/server.go
+++ b/server.go
@@ -9,11 +9,12 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"time"
 
-	centreon "github.com/tphakala/centreon-go-client"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	centreon "github.com/tphakala/centreon-go-client"
 	"github.com/tphakala/centreon-mcp-go/tools"
 )
 
@@ -140,6 +141,11 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 		sharedClient = client
 	} else {
 		tokenCache = NewTokenCache(tokenCacheTTL)
+		if len(cfg.AllowedHosts) == 0 {
+			logger.Warn("gateway: no host allowlist configured; X-Centreon-Host accepts any value (set CENTREON_ALLOWED_HOSTS to restrict)")
+		} else {
+			logger.Info("gateway: host allowlist active", "count", len(cfg.AllowedHosts))
+		}
 	}
 
 	getServer := func(r *http.Request) *mcp.Server {
@@ -207,6 +213,11 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		return nil
 	}
 
+	if !hostAllowed(host, cfg.AllowedHosts) {
+		logger.Error("gateway: host not in allowlist", "host", host)
+		return nil
+	}
+
 	gwCfg := &Config{
 		Host:            host,
 		AllowSelfSigned: cfg.AllowSelfSigned,
@@ -248,4 +259,16 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 
 	logger.Debug("gateway: created per-request client", "host", host)
 	return buildServer(client, logger)
+}
+
+// hostAllowed reports whether host may be used in gateway mode. An empty
+// allowlist disables the check and accepts any host. Otherwise the host must
+// match an allowlist entry exactly. The comparison uses the raw header value
+// (net/http already strips surrounding whitespace from header values) so the
+// value that is validated here is identical to the one used to build the client.
+func hostAllowed(host string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	return slices.Contains(allowed, host)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHostAllowed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		host    string
+		allowed []string
+		want    bool
+	}{
+		{"nil allowlist accepts any host", "https://any.example.com", nil, true},
+		{"empty allowlist accepts any host", "https://any.example.com", []string{}, true},
+		{"host present in allowlist", "https://centreon.example.com", []string{"https://centreon.example.com"}, true},
+		{"host present among several", "https://b.example.com", []string{"https://a.example.com", "https://b.example.com"}, true},
+		{"host absent from allowlist", "https://evil.example.com", []string{"https://centreon.example.com"}, false},
+		{"exact match rejects surrounding whitespace", "  https://centreon.example.com  ", []string{"https://centreon.example.com"}, false},
+		{"match is case-sensitive", "https://Centreon.Example.com", []string{"https://centreon.example.com"}, false},
+		{"empty host with non-empty allowlist is rejected", "", []string{"https://centreon.example.com"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hostAllowed(tt.host, tt.allowed); got != tt.want {
+				t.Errorf("hostAllowed(%q, %v) = %v, want %v", tt.host, tt.allowed, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGatewayServer_HostAllowlist exercises the enforcement point itself, not
+// just the hostAllowed helper: it confirms gatewayServer rejects a host that is
+// not on the allowlist (returns nil) and admits one that is. A token is
+// supplied so the token branch is taken and no network login is attempted.
+func TestGatewayServer_HostAllowlist(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	cache := NewTokenCache(time.Minute)
+
+	newReq := func(host string) *http.Request {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+		r.Header.Set("X-Centreon-Host", host)
+		r.Header.Set("X-Centreon-Token", "dummy-token")
+		return r
+	}
+
+	t.Run("host not in allowlist is rejected", func(t *testing.T) {
+		cfg := &Config{AllowedHosts: []string{"https://allowed.example.com"}}
+		if srv := gatewayServer(newReq("https://evil.example.com"), cfg, cache, logger, nil); srv != nil {
+			t.Error("expected nil server for host not in allowlist, got non-nil")
+		}
+	})
+
+	t.Run("host in allowlist is accepted", func(t *testing.T) {
+		cfg := &Config{AllowedHosts: []string{"https://allowed.example.com"}}
+		if srv := gatewayServer(newReq("https://allowed.example.com"), cfg, cache, logger, nil); srv == nil {
+			t.Error("expected non-nil server for allowed host, got nil")
+		}
+	})
+
+	t.Run("empty allowlist accepts any host", func(t *testing.T) {
+		cfg := &Config{}
+		if srv := gatewayServer(newReq("https://anything.example.com"), cfg, cache, logger, nil); srv == nil {
+			t.Error("expected non-nil server when allowlist is empty, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Gateway mode built a per-request Centreon client from the `X-Centreon-Host` header with only a non-empty check, so an exposed endpoint could be pointed at any host (an SSRF / open-proxy surface). This adds an optional `CENTREON_ALLOWED_HOSTS` allowlist (comma-separated). When set, `gatewayServer` rejects any `X-Centreon-Host` that does not match an entry exactly (case-sensitive, full-string match) before building any client. When unset or empty, behavior is unchanged (any host accepted) and the server logs a startup warning. A value set to a non-empty string that parses to no valid entries fails fast at startup.

It also extracts `MCP_HTTP_PORT` parsing into `loadHTTPPort` (keeps `LoadConfig` under the repo's cognitive/cyclomatic complexity limits once the new logic is added; behavior preserved byte-for-byte) and adds a `defaultHTTPPort` constant.

## Related Issues

Closes #4

Discovered during review and filed separately: #26 (a pre-existing gateway token-cache issue, out of scope for this change).

## Test Plan

- [x] `hostAllowed` exact-match truth table: rejects absent host, case-sensitive, empty allowlist accepts any host, exact match rejects surrounding whitespace
- [x] `gatewayServer` enforcement point: disallowed host returns nil, allowed host and empty allowlist return a server (hermetic; the token branch skips network login)
- [x] Allowlist parsing: trim, drop empty entries, set-but-no-valid-entries errors, unset/empty yields no restriction
- [x] `MCP_HTTP_PORT` validation: default 8080, valid, non-numeric, below and above range
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues), and `go test -race ./...` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway mode now supports host allowlist configuration to restrict accepted hosts via comma-separated values with case-sensitive matching.

* **Documentation**
  * Added configuration guidance for the new host allowlist feature, including validation rules and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->