### PR TITLE
fix: bind gateway token cache key to the password (#26)

### DIFF
--- a/server.go
+++ b/server.go
@@ -227,7 +227,7 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 	case token != "":
 		gwCfg.Token = token
 	case username != "" && password != "":
-		if cached, ok := tokenCache.Get(host, username); ok {
+		if cached, ok := tokenCache.Get(host, username, password); ok {
 			logger.Debug("gateway: using cached token", "host", host)
 			gwCfg.Token = cached
 		} else {
@@ -252,7 +252,7 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		}
 		// Cache the token for subsequent requests
 		if tok := client.Token(); tok != "" {
-			tokenCache.Set(host, username, tok)
+			tokenCache.Set(host, username, password, tok)
 			logger.Debug("gateway: cached token after login", "host", host)
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -72,4 +74,80 @@ func TestGatewayServer_HostAllowlist(t *testing.T) {
 			t.Error("expected non-nil server when allowlist is empty, got nil")
 		}
 	})
+}
+
+// TestGatewayServer_TokenCachePinsPassword is an end-to-end regression guard
+// for #26: it drives gatewayServer against a fake Centreon login endpoint and
+// proves the request password actually flows into the cache key. It counts real
+// login attempts: the correct password logs in once and is then served from
+// cache (no second login), while a wrong password must NOT reuse the cached
+// token, so it forces a fresh login that the fake server rejects, and the
+// request is denied. If gatewayServer passed anything other than the real
+// password into Get/Set, the wrong-password request would reuse the cached
+// token and this test would fail.
+func TestGatewayServer_TokenCachePinsPassword(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	const goodPass = "correct-horse"
+	var loginCount int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /centreon/api/latest/login", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&loginCount, 1)
+		var body struct {
+			Security struct {
+				Credentials struct {
+					Login    string `json:"login"`
+					Password string `json:"password"`
+				} `json:"credentials"`
+			} `json:"security"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if body.Security.Credentials.Password != goodPass {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": 1, "message": "bad credentials"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"security": map[string]any{"token": "tok-123"}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := &Config{} // no allowlist restriction
+	cache := NewTokenCache(time.Minute)
+
+	req := func(pass string) *http.Request {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+		r.Header.Set("X-Centreon-Host", srv.URL)
+		r.Header.Set("X-Centreon-Username", "admin")
+		r.Header.Set("X-Centreon-Password", pass)
+		return r
+	}
+
+	// Request 1: correct password -> one real login, token cached, server built.
+	if s := gatewayServer(req(goodPass), cfg, cache, logger, nil); s == nil {
+		t.Fatal("request 1 (correct password): expected a server, got nil")
+	}
+	if n := atomic.LoadInt32(&loginCount); n != 1 {
+		t.Fatalf("request 1: expected exactly 1 login, got %d", n)
+	}
+
+	// Request 2: same correct password -> cache hit, no new login.
+	if s := gatewayServer(req(goodPass), cfg, cache, logger, nil); s == nil {
+		t.Fatal("request 2 (cached): expected a server, got nil")
+	}
+	if n := atomic.LoadInt32(&loginCount); n != 1 {
+		t.Fatalf("request 2: expected cache hit (still 1 login), got %d", n)
+	}
+
+	// Request 3: wrong password -> cache miss -> fresh login -> 401 -> denied.
+	if s := gatewayServer(req("wrong-pass"), cfg, cache, logger, nil); s != nil {
+		t.Error("request 3 (wrong password): expected nil (denied), got a server")
+	}
+	if n := atomic.LoadInt32(&loginCount); n != 2 {
+		t.Fatalf("request 3: wrong password must force a fresh login (expected 2 total), got %d", n)
+	}
 }

--- a/token_cache.go
+++ b/token_cache.go
@@ -31,8 +31,16 @@ func NewTokenCache(ttl time.Duration) *TokenCache {
 }
 
 func cacheKey(host, username, password string) string {
-	h := sha256.Sum256([]byte(host + "\x00" + username + "\x00" + password))
-	return fmt.Sprintf("%x", h)
+	// Stream each field into the hash separately (NUL-separated) rather than
+	// building one concatenated string, to avoid an extra in-memory copy of the
+	// plaintext password. hash.Hash.Write never returns an error.
+	h := sha256.New()
+	_, _ = h.Write([]byte(host))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(username))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(password))
+	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 // Get returns a cached token if it exists and hasn't expired. The password is

--- a/token_cache.go
+++ b/token_cache.go
@@ -12,7 +12,10 @@ type tokenEntry struct {
 	expires time.Time
 }
 
-// TokenCache stores auth tokens keyed by host+username with TTL.
+// TokenCache stores auth tokens keyed by host+username+password with TTL.
+// Binding the key to the password ensures a request presenting a different
+// (e.g. wrong) password misses the cache and is forced through a real login,
+// rather than reusing a token minted for the correct password.
 type TokenCache struct {
 	mu      sync.Mutex
 	ttl     time.Duration
@@ -27,17 +30,18 @@ func NewTokenCache(ttl time.Duration) *TokenCache {
 	}
 }
 
-func cacheKey(host, username string) string {
-	h := sha256.Sum256([]byte(host + "\x00" + username))
+func cacheKey(host, username, password string) string {
+	h := sha256.Sum256([]byte(host + "\x00" + username + "\x00" + password))
 	return fmt.Sprintf("%x", h)
 }
 
-// Get returns a cached token if it exists and hasn't expired.
-func (c *TokenCache) Get(host, username string) (string, bool) {
+// Get returns a cached token if it exists and hasn't expired. The password is
+// part of the key, so a different password will not match a cached entry.
+func (c *TokenCache) Get(host, username, password string) (string, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := cacheKey(host, username)
+	key := cacheKey(host, username, password)
 	entry, ok := c.entries[key]
 	if !ok || time.Now().After(entry.expires) {
 		delete(c.entries, key)
@@ -47,7 +51,7 @@ func (c *TokenCache) Get(host, username string) (string, bool) {
 }
 
 // Set stores a token in the cache and sweeps expired entries.
-func (c *TokenCache) Set(host, username, token string) {
+func (c *TokenCache) Set(host, username, password, token string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -58,7 +62,7 @@ func (c *TokenCache) Set(host, username, token string) {
 		}
 	}
 
-	key := cacheKey(host, username)
+	key := cacheKey(host, username, password)
 	c.entries[key] = tokenEntry{
 		token:   token,
 		expires: now.Add(c.ttl),

--- a/token_cache_test.go
+++ b/token_cache_test.go
@@ -7,9 +7,9 @@ import (
 
 func TestTokenCache_SetAndGet(t *testing.T) {
 	tc := NewTokenCache(50 * time.Minute)
-	tc.Set("host1", "user1", "token-abc")
+	tc.Set("host1", "user1", "pass1", "token-abc")
 
-	tok, ok := tc.Get("host1", "user1")
+	tok, ok := tc.Get("host1", "user1", "pass1")
 	if !ok {
 		t.Fatal("expected token to be found")
 	}
@@ -20,11 +20,11 @@ func TestTokenCache_SetAndGet(t *testing.T) {
 
 func TestTokenCache_Expired(t *testing.T) {
 	tc := NewTokenCache(1 * time.Millisecond)
-	tc.Set("host1", "user1", "token-abc")
+	tc.Set("host1", "user1", "pass1", "token-abc")
 
 	time.Sleep(5 * time.Millisecond)
 
-	_, ok := tc.Get("host1", "user1")
+	_, ok := tc.Get("host1", "user1", "pass1")
 	if ok {
 		t.Error("expected token to be expired")
 	}
@@ -32,12 +32,12 @@ func TestTokenCache_Expired(t *testing.T) {
 
 func TestTokenCache_DifferentKeys(t *testing.T) {
 	tc := NewTokenCache(50 * time.Minute)
-	tc.Set("host1", "user1", "token-1")
-	tc.Set("host2", "user2", "token-2")
+	tc.Set("host1", "user1", "pass1", "token-1")
+	tc.Set("host2", "user2", "pass2", "token-2")
 
-	tok1, ok1 := tc.Get("host1", "user1")
-	tok2, ok2 := tc.Get("host2", "user2")
-	_, ok3 := tc.Get("host1", "user2")
+	tok1, ok1 := tc.Get("host1", "user1", "pass1")
+	tok2, ok2 := tc.Get("host2", "user2", "pass2")
+	_, ok3 := tc.Get("host1", "user2", "pass1")
 
 	if !ok1 || tok1 != "token-1" {
 		t.Errorf("expected token-1, got %q", tok1)
@@ -47,5 +47,23 @@ func TestTokenCache_DifferentKeys(t *testing.T) {
 	}
 	if ok3 {
 		t.Error("expected no token for host1+user2")
+	}
+}
+
+// TestTokenCache_WrongPasswordMisses pins the #26 fix: a cached token minted
+// for one password must not be served to a request presenting a different
+// password. A different password produces a different key, so it misses the
+// cache and is forced through a real login.
+func TestTokenCache_WrongPasswordMisses(t *testing.T) {
+	tc := NewTokenCache(50 * time.Minute)
+	tc.Set("host1", "user1", "correct-pass", "token-abc")
+
+	if _, ok := tc.Get("host1", "user1", "wrong-pass"); ok {
+		t.Error("expected cache miss for a different password, got a hit")
+	}
+
+	tok, ok := tc.Get("host1", "user1", "correct-pass")
+	if !ok || tok != "token-abc" {
+		t.Errorf("expected the correct password to hit and return token-abc, got %q ok=%v", tok, ok)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a Critical authentication bypass in gateway mode (#26). The per-request token cache was keyed on `(host, username)` only, so within the 50-minute TTL a request presenting a valid username but a **wrong password** hit the cache, reused the token minted for the correct password, and skipped authentication entirely.

The fix binds the cache key to the password: `cacheKey` now hashes `sha256(host \x00 username \x00 password)`, and `TokenCache.Get`/`Set` take the password. A different password produces a different key, misses the cache, and is forced through a real login that Centreon rejects. The correct password still hits the cache, so the fast path is preserved. Only the sha256 digest is used as the map key; the plaintext password is never stored.

## Related Issues

Closes #26

Found during the same review, filed separately (both pre-existing, out of scope here): #29 (the token cache is unbounded and sweeps under a global lock, a DoS surface that this change widens slightly by adding the password as a third key dimension) and #28 (HTTPS scheme enforcement for host inputs).

## Test Plan

- [x] `TestTokenCache_WrongPasswordMisses` pins the key derivation: a wrong password misses, the correct one hits (sabotage-verified: reverting the key to ignore the password makes it fail)
- [x] `TestGatewayServer_TokenCachePinsPassword` drives `gatewayServer` end-to-end against a fake Centreon login endpoint, proving the real request password flows into the cache key: correct password logs in once then serves from cache; wrong password forces a fresh login (denied) instead of reusing the cached token (sabotage-verified against three wiring mutations)
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues), `go test -race ./...` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved gateway token caching so credentials with different passwords no longer share cached authentication tokens.
  - Incorrect passwords now trigger fresh authentication attempts and are properly rejected.
  - Valid credentials continue to reuse their cached tokens.

- **Tests**
  - Added coverage for password-specific token isolation and gateway authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->