### PR TITLE
perf: parallelize centreon_platform_status API reads (#6)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/tphakala/centreon-go-client v1.7.0
+	golang.org/x/sync v0.22.0
 )
 
 require (
@@ -14,7 +15,6 @@ require (
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/tools/status_tools.go
+++ b/tools/status_tools.go
@@ -29,9 +29,10 @@ func RegisterStatusTools(s *mcp.Server, client *centreon.Client, logger *slog.Lo
 
 // logReadError logs a failed platform-status read at Error level, unless the
 // read was cancelled (context.Canceled): either a sibling read failed first and
-// errgroup cancelled this one, or the caller cancelled the request. It then
-// returns the wrapped error for errgroup. Skipping cancelled reads keeps one
-// logical failure to one error line instead of three.
+// errgroup cancelled this one, or the caller cancelled the request. A real
+// timeout (context.DeadlineExceeded) is not a cancellation and is still logged.
+// It then returns the wrapped error for errgroup. Skipping cancelled reads keeps
+// one logical failure to one error line instead of three.
 func logReadError(logger *slog.Logger, part, msg string, err error) error {
 	if !errors.Is(err, context.Canceled) {
 		logger.Error("failed: centreon_platform_status ("+part+")", "error", err)

--- a/tools/status_tools.go
+++ b/tools/status_tools.go
@@ -2,10 +2,13 @@ package tools
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"golang.org/x/sync/errgroup"
 )
 
 // PlatformStatus combines host status counts, service status counts, and monitoring servers.
@@ -24,29 +27,78 @@ func RegisterStatusTools(s *mcp.Server, client *centreon.Client, logger *slog.Lo
 	}, platformStatusHandler(client, logger))
 }
 
+// logReadError logs a failed platform-status read at Error level, unless the
+// read was cancelled (context.Canceled): either a sibling read failed first and
+// errgroup cancelled this one, or the caller cancelled the request. It then
+// returns the wrapped error for errgroup. Skipping cancelled reads keeps one
+// logical failure to one error line instead of three.
+func logReadError(logger *slog.Logger, part, msg string, err error) error {
+	if !errors.Is(err, context.Canceled) {
+		logger.Error("failed: centreon_platform_status ("+part+")", "error", err)
+	}
+	return fmt.Errorf("%s: %w", msg, err)
+}
+
 func platformStatusHandler(client *centreon.Client, logger *slog.Logger) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+	return platformStatusHandlerFn(
+		client.MonitoringHosts.StatusCounts,
+		client.MonitoringServices.StatusCounts,
+		func(ctx context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+			return client.MonitoringServers.List(ctx)
+		},
+		logger,
+	)
+}
+
+// platformStatusHandlerFn runs the three independent status reads concurrently
+// and combines them, so total latency is the slowest single call rather than
+// their sum. Taking the reads as function values keeps it unit-testable without
+// a live Centreon client.
+func platformStatusHandlerFn(
+	fetchHosts func(context.Context) (*centreon.HostStatusCount, error),
+	fetchServices func(context.Context) (*centreon.ServiceStatusCount, error),
+	fetchServers func(context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error),
+	logger *slog.Logger,
+) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		ctx = centreon.WithToolName(ctx, "centreon_platform_status")
 		logger.Debug("centreon_platform_status")
 
-		hosts, err := client.MonitoringHosts.StatusCounts(ctx)
-		if err != nil {
-			logger.Error("failed: centreon_platform_status (hosts)", "error", err)
-			res, anyVal := errorResult("failed to get host status counts: %v", err)
-			return res, anyVal, nil
-		}
-
-		services, err := client.MonitoringServices.StatusCounts(ctx)
-		if err != nil {
-			logger.Error("failed: centreon_platform_status (services)", "error", err)
-			res, anyVal := errorResult("failed to get service status counts: %v", err)
-			return res, anyVal, nil
-		}
-
-		servers, err := client.MonitoringServers.List(ctx)
-		if err != nil {
-			logger.Error("failed: centreon_platform_status (servers)", "error", err)
-			res, anyVal := errorResult("failed to get monitoring servers: %v", err)
+		var (
+			hosts    *centreon.HostStatusCount
+			services *centreon.ServiceStatusCount
+			servers  *centreon.ListResponse[centreon.MonitoringServer]
+		)
+		// errgroup cancels the shared context on the first failure so the other
+		// two reads can abort early. Each goroutine writes only its own variable,
+		// and g.Wait() establishes the happens-before for reading them afterwards.
+		g, gctx := errgroup.WithContext(ctx)
+		g.Go(func() error {
+			h, err := fetchHosts(gctx)
+			if err != nil {
+				return logReadError(logger, "hosts", "failed to get host status counts", err)
+			}
+			hosts = h
+			return nil
+		})
+		g.Go(func() error {
+			s, err := fetchServices(gctx)
+			if err != nil {
+				return logReadError(logger, "services", "failed to get service status counts", err)
+			}
+			services = s
+			return nil
+		})
+		g.Go(func() error {
+			srv, err := fetchServers(gctx)
+			if err != nil {
+				return logReadError(logger, "servers", "failed to get monitoring servers", err)
+			}
+			servers = srv
+			return nil
+		})
+		if err := g.Wait(); err != nil {
+			res, anyVal := errorResult("%v", err)
 			return res, anyVal, nil
 		}
 

--- a/tools/status_tools_test.go
+++ b/tools/status_tools_test.go
@@ -1,0 +1,238 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	centreon "github.com/tphakala/centreon-go-client"
+)
+
+// errorCountHandler is a slog.Handler that counts records emitted at Error
+// level or above. Safe for the concurrent logging the errgroup goroutines do.
+type errorCountHandler struct{ count atomic.Int64 }
+
+func (h *errorCountHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+// slog.Handler requires Record by value, so gocritic's hugeParam does not apply.
+//
+//nolint:gocritic // slog.Handler.Handle signature is fixed by the interface.
+func (h *errorCountHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level >= slog.LevelError {
+		h.count.Add(1)
+	}
+	return nil
+}
+
+func (h *errorCountHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *errorCountHandler) WithGroup(string) slog.Handler { return h }
+
+// textOf extracts the first text content from a tool result.
+func textOf(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content is %T, want *mcp.TextContent", res.Content[0])
+	}
+	return tc.Text
+}
+
+func TestPlatformStatusHandlerFn_CombinesResults(t *testing.T) {
+	var hostsCalled, servicesCalled, serversCalled bool
+	fetchHosts := func(_ context.Context) (*centreon.HostStatusCount, error) {
+		hostsCalled = true
+		return &centreon.HostStatusCount{Total: 11}, nil
+	}
+	fetchServices := func(_ context.Context) (*centreon.ServiceStatusCount, error) {
+		servicesCalled = true
+		return &centreon.ServiceStatusCount{Total: 22}, nil
+	}
+	fetchServers := func(_ context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+		serversCalled = true
+		return &centreon.ListResponse[centreon.MonitoringServer]{
+			Result: []centreon.MonitoringServer{{ID: 7, Name: "poller-7"}},
+		}, nil
+	}
+
+	handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t))
+	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error result: %s", textOf(t, res))
+	}
+	if !hostsCalled || !servicesCalled || !serversCalled {
+		t.Fatalf("not all fetchers called: hosts=%v services=%v servers=%v", hostsCalled, servicesCalled, serversCalled)
+	}
+
+	var got PlatformStatus
+	if err := json.Unmarshal([]byte(textOf(t, res)), &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if got.Hosts == nil || got.Hosts.Total != 11 {
+		t.Errorf("hosts not placed correctly: %+v", got.Hosts)
+	}
+	if got.Services == nil || got.Services.Total != 22 {
+		t.Errorf("services not placed correctly: %+v", got.Services)
+	}
+	if got.Servers == nil || len(got.Servers.Result) != 1 || got.Servers.Result[0].Name != "poller-7" {
+		t.Errorf("servers not placed correctly: %+v", got.Servers)
+	}
+}
+
+// TestPlatformStatusHandlerFn_RunsConcurrently proves the three reads run in
+// parallel: each fetcher blocks until every fetcher has started. A sequential
+// implementation can never get all three started at once, so it fails to reach
+// the barrier before the deadline. Regression to sequential turns this red.
+func TestPlatformStatusHandlerFn_RunsConcurrently(t *testing.T) {
+	started := make(chan struct{}, 3)
+	release := make(chan struct{})
+	gate := func() {
+		started <- struct{}{}
+		<-release
+	}
+	fetchHosts := func(_ context.Context) (*centreon.HostStatusCount, error) {
+		gate()
+		return &centreon.HostStatusCount{}, nil
+	}
+	fetchServices := func(_ context.Context) (*centreon.ServiceStatusCount, error) {
+		gate()
+		return &centreon.ServiceStatusCount{}, nil
+	}
+	fetchServers := func(_ context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+		gate()
+		return &centreon.ListResponse[centreon.MonitoringServer]{}, nil
+	}
+
+	handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t))
+	done := make(chan struct{})
+	go func() {
+		_, _, _ = handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for i := range 3 {
+		select {
+		case <-started:
+		case <-deadline:
+			close(release) // unblock any goroutine already waiting so the handler can finish
+			t.Fatalf("fetchers did not run concurrently: only %d of 3 started before deadline", i)
+		}
+	}
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not complete after release")
+	}
+}
+
+// TestPlatformStatusHandlerFn_ReportsError checks that whichever single read
+// fails, the error result names that specific call. Each of the three branches
+// emits a distinct message, so all three are exercised to catch a copy-paste
+// slip that routes one branch through another's wording.
+func TestPlatformStatusHandlerFn_ReportsError(t *testing.T) {
+	okHosts := func(context.Context) (*centreon.HostStatusCount, error) {
+		return &centreon.HostStatusCount{}, nil
+	}
+	okServices := func(context.Context) (*centreon.ServiceStatusCount, error) {
+		return &centreon.ServiceStatusCount{}, nil
+	}
+	okServers := func(context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+		return &centreon.ListResponse[centreon.MonitoringServer]{}, nil
+	}
+
+	tests := []struct {
+		name        string
+		failing     string
+		wantMessage string
+	}{
+		{"hosts", "hosts", "host status counts"},
+		{"services", "services", "service status counts"},
+		{"servers", "servers", "monitoring servers"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fetchHosts, fetchServices, fetchServers := okHosts, okServices, okServers
+			switch tt.failing {
+			case "hosts":
+				fetchHosts = func(context.Context) (*centreon.HostStatusCount, error) {
+					return nil, errors.New("boom")
+				}
+			case "services":
+				fetchServices = func(context.Context) (*centreon.ServiceStatusCount, error) {
+					return nil, errors.New("boom")
+				}
+			case "servers":
+				fetchServers = func(context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+					return nil, errors.New("boom")
+				}
+			}
+
+			handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t))
+			res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatal("expected error result")
+			}
+			if text := textOf(t, res); !strings.Contains(text, tt.wantMessage) {
+				t.Errorf("error result should identify the failing call %q, got: %q", tt.wantMessage, text)
+			}
+		})
+	}
+}
+
+// TestPlatformStatusHandlerFn_SuppressesCancellationLogs pins that a single
+// genuine failure produces a single Error log line. When one read fails,
+// errgroup cancels the shared context and the two in-flight sibling reads
+// return context.Canceled; those induced cancellations must not be logged at
+// Error level, or one logical failure inflates into three ERROR lines.
+func TestPlatformStatusHandlerFn_SuppressesCancellationLogs(t *testing.T) {
+	handler := &errorCountHandler{}
+	logger := slog.New(handler)
+
+	// services fails for real; hosts and servers block until the shared context
+	// is cancelled (which errgroup does on the first failure) and then return
+	// that cancellation error, reproducing the induced-cancellation case.
+	fetchHosts := func(ctx context.Context) (*centreon.HostStatusCount, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	fetchServices := func(_ context.Context) (*centreon.ServiceStatusCount, error) {
+		return nil, errors.New("real failure")
+	}
+	fetchServers := func(ctx context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	h := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, logger)
+	res, _, err := h(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error result")
+	}
+	if got := handler.count.Load(); got != 1 {
+		t.Errorf("expected exactly 1 Error log line (the real failure), got %d", got)
+	}
+	if text := textOf(t, res); !strings.Contains(text, "service status counts") {
+		t.Errorf("error should name the real failing call, got: %q", text)
+	}
+}


### PR DESCRIPTION
## Summary

Parallelizes the three independent Centreon API reads behind `centreon_platform_status` (host status counts, service status counts, monitoring servers) with `errgroup.WithContext`, so the tool's latency is the slowest single read instead of the sum of all three.

The handler is refactored into a testable inner `platformStatusHandlerFn` that takes the three reads as function values, matching the existing `pollerApplyHandlerFn` pattern in the package, so the concurrency is unit-testable without a live Centreon client. Each goroutine writes only its own result variable and the combined `PlatformStatus` is assembled after `g.Wait()`, so the read side is race-free (verified under `-race`). The success-path JSON output and the per-call error messages are byte-for-byte unchanged.

### Notes

- When more than one read fails, the surfaced error is now whichever failed first rather than always the hosts error; each message still names its own failing call. This is not a contract change: the tool returns an error naming a failing call either way.
- A read cancelled because a sibling failed first, or because the caller cancelled the request, returns `context.Canceled`; `logReadError` skips logging those at Error level, so one logical failure produces one ERROR log line rather than three.
- `golang.org/x/sync` moves from an indirect to a direct dependency (same version `v0.22.0`, already present in the module graph).

## Related Issues

Closes #6

## Test Plan

- [x] `go test -race ./...` and `golangci-lint run` pass clean
- [x] `TestPlatformStatusHandlerFn_CombinesResults`: all three reads run and each result lands in the correct field
- [x] `TestPlatformStatusHandlerFn_RunsConcurrently`: barrier test that fails if the reads are serialized
- [x] `TestPlatformStatusHandlerFn_ReportsError`: table-driven over all three error branches
- [x] `TestPlatformStatusHandlerFn_SuppressesCancellationLogs`: one genuine failure yields exactly one ERROR log line


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improved Reliability**
  * Platform status information is now collected concurrently, reducing wait times.
  * Results are combined after all required checks complete successfully.
  * Failures are reported clearly without duplicate cancellation errors.

* **Tests**
  * Added coverage for successful status aggregation, concurrent processing, individual failures, and cancellation handling.
  * Added verification that status checks run concurrently and return clear error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->