### PR TITLE
fix: bound the gateway token cache with an LRU (#29)

### DIFF
--- a/token_cache.go
+++ b/token_cache.go
@@ -1,32 +1,60 @@
 package main
 
 import (
+	"container/list"
 	"crypto/sha256"
 	"fmt"
 	"sync"
 	"time"
 )
 
+// tokenCacheMaxEntries bounds how many auth tokens the gateway caches at once.
+// In gateway mode the cache key is derived from request headers (host, username,
+// password), so an unbounded cache lets a caller with distinct credentials grow
+// it without limit. The cap turns that into a fixed memory ceiling; legitimate
+// deployments have far fewer distinct credential sets than this.
+const tokenCacheMaxEntries = 4096
+
 type tokenEntry struct {
 	token   string
 	expires time.Time
+	el      *list.Element // position in ll; el.Value holds the map key (string)
 }
 
-// TokenCache stores auth tokens keyed by host+username+password with TTL.
-// Binding the key to the password ensures a request presenting a different
-// (e.g. wrong) password misses the cache and is forced through a real login,
-// rather than reusing a token minted for the correct password.
+// TokenCache is a bounded, TTL'd LRU of auth tokens keyed by
+// host+username+password. Binding the key to the password ensures a request
+// presenting a different (e.g. wrong) password misses the cache and is forced
+// through a real login, rather than reusing a token minted for the correct
+// password.
+//
+// The cache is bounded to a fixed number of entries and evicts the
+// least-recently-used entry on overflow, so distinct (attacker-influenced)
+// gateway keys cannot exhaust memory. Expired entries are dropped lazily on
+// access; there is no whole-map sweep on the write path.
 type TokenCache struct {
-	mu      sync.Mutex
-	ttl     time.Duration
-	entries map[string]tokenEntry
+	mu         sync.Mutex
+	ttl        time.Duration
+	maxEntries int
+	ll         *list.List             // front = most recently used; Value is the key
+	entries    map[string]*tokenEntry // key -> entry
 }
 
-// NewTokenCache creates a new token cache with the given TTL.
+// NewTokenCache creates a token cache with the given TTL and the default cap.
 func NewTokenCache(ttl time.Duration) *TokenCache {
+	return newTokenCache(ttl, tokenCacheMaxEntries)
+}
+
+// newTokenCache creates a token cache with an explicit entry cap. Split out from
+// NewTokenCache so eviction can be exercised with a small cap in tests.
+func newTokenCache(ttl time.Duration, maxEntries int) *TokenCache {
+	if maxEntries < 1 {
+		maxEntries = 1
+	}
 	return &TokenCache{
-		ttl:     ttl,
-		entries: make(map[string]tokenEntry),
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		ll:         list.New(),
+		entries:    make(map[string]*tokenEntry),
 	}
 }
 
@@ -44,35 +72,71 @@ func cacheKey(host, username, password string) string {
 }
 
 // Get returns a cached token if it exists and hasn't expired. The password is
-// part of the key, so a different password will not match a cached entry.
+// part of the key, so a different password will not match a cached entry. A hit
+// marks the entry most-recently-used; an expired entry is dropped.
 func (c *TokenCache) Get(host, username, password string) (string, bool) {
+	// Hash before taking the lock: cacheKey is pure, and the password comes from
+	// an attacker-influenced request header, so hashing it must not hold the
+	// global mutex. Under the lock only the O(1) map/list work runs.
+	key := cacheKey(host, username, password)
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := cacheKey(host, username, password)
 	entry, ok := c.entries[key]
-	if !ok || time.Now().After(entry.expires) {
-		delete(c.entries, key)
+	if !ok {
 		return "", false
 	}
+	if time.Now().After(entry.expires) {
+		c.remove(key, entry)
+		return "", false
+	}
+	c.ll.MoveToFront(entry.el)
 	return entry.token, true
 }
 
-// Set stores a token in the cache and sweeps expired entries.
+// Set stores a token, refreshing an existing key in place. When the cache is at
+// capacity and the key is new, the least-recently-used entry is evicted first,
+// so the cache stays within its fixed bound.
 func (c *TokenCache) Set(host, username, password, token string) {
+	// Hash before taking the lock (see Get): the password is attacker-influenced
+	// and cacheKey is pure, so the hash must not run under the global mutex.
+	key := cacheKey(host, username, password)
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	now := time.Now()
-	for k, e := range c.entries {
-		if now.After(e.expires) {
-			delete(c.entries, k)
-		}
+	expires := time.Now().Add(c.ttl)
+
+	if entry, ok := c.entries[key]; ok {
+		entry.token = token
+		entry.expires = expires
+		c.ll.MoveToFront(entry.el)
+		return
 	}
 
-	key := cacheKey(host, username, password)
-	c.entries[key] = tokenEntry{
-		token:   token,
-		expires: now.Add(c.ttl),
+	if c.ll.Len() >= c.maxEntries {
+		c.removeOldest()
 	}
+	el := c.ll.PushFront(key)
+	c.entries[key] = &tokenEntry{token: token, expires: expires, el: el}
+}
+
+// remove drops a known key/entry pair from both the list and the index.
+// The caller holds mu.
+func (c *TokenCache) remove(key string, entry *tokenEntry) {
+	c.ll.Remove(entry.el)
+	delete(c.entries, key)
+}
+
+// removeOldest evicts the least-recently-used entry (the back of the list).
+// The caller holds mu.
+func (c *TokenCache) removeOldest() {
+	back := c.ll.Back()
+	if back == nil {
+		return
+	}
+	key, _ := back.Value.(string)
+	c.ll.Remove(back)
+	delete(c.entries, key)
 }

--- a/token_cache_test.go
+++ b/token_cache_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -27,6 +29,14 @@ func TestTokenCache_Expired(t *testing.T) {
 	_, ok := tc.Get("host1", "user1", "pass1")
 	if ok {
 		t.Error("expected token to be expired")
+	}
+	// The lazy expiry drop must clear the entry from BOTH the map and the LRU
+	// list; if it only deleted the map key the list would leak a dead element.
+	if n := len(tc.entries); n != 0 {
+		t.Errorf("expired Get should drop the map entry: %d remain", n)
+	}
+	if n := tc.ll.Len(); n != 0 {
+		t.Errorf("expired Get should drop the LRU element: %d remain", n)
 	}
 }
 
@@ -65,5 +75,115 @@ func TestTokenCache_WrongPasswordMisses(t *testing.T) {
 	tok, ok := tc.Get("host1", "user1", "correct-pass")
 	if !ok || tok != "token-abc" {
 		t.Errorf("expected the correct password to hit and return token-abc, got %q ok=%v", tok, ok)
+	}
+}
+
+// TestTokenCache_BoundedToMaxEntries pins the #29 DoS fix: distinct keys, which
+// in gateway mode come from attacker-influenced request headers, must not grow
+// the cache without bound. Flooding it with far more keys than the cap leaves
+// the cache at the cap, not at the flood size.
+func TestTokenCache_BoundedToMaxEntries(t *testing.T) {
+	tc := newTokenCache(50*time.Minute, 3)
+	for i := range 100 {
+		tc.Set("host", "user", fmt.Sprintf("pass-%d", i), "tok")
+	}
+	// The flood deterministically fills the cap, so the cache must sit at
+	// exactly 3: fewer would mean an over-eviction bug, more an unbounded one.
+	if got := len(tc.entries); got != 3 {
+		t.Fatalf("cache should be filled to exactly the cap: got %d entries, want 3", got)
+	}
+	if ll, m := tc.ll.Len(), len(tc.entries); ll != m {
+		t.Fatalf("list/map desync: list=%d map=%d", ll, m)
+	}
+}
+
+// TestTokenCache_EvictsLeastRecentlyUsed pins that eviction is LRU: a Get keeps
+// an entry alive, and the untouched one is the one dropped when the cap is hit.
+func TestTokenCache_EvictsLeastRecentlyUsed(t *testing.T) {
+	tc := newTokenCache(50*time.Minute, 2)
+	tc.Set("h", "u", "A", "tok-a")
+	tc.Set("h", "u", "B", "tok-b")
+
+	// Touch A so B becomes the least-recently-used entry.
+	if _, ok := tc.Get("h", "u", "A"); !ok {
+		t.Fatal("A should still be present before eviction")
+	}
+
+	// Inserting C is over cap, so the LRU entry (B) is evicted.
+	tc.Set("h", "u", "C", "tok-c")
+
+	if _, ok := tc.Get("h", "u", "B"); ok {
+		t.Error("B should have been evicted as least-recently-used")
+	}
+	if tok, ok := tc.Get("h", "u", "A"); !ok || tok != "tok-a" {
+		t.Errorf("A should survive eviction, got %q ok=%v", tok, ok)
+	}
+	if tok, ok := tc.Get("h", "u", "C"); !ok || tok != "tok-c" {
+		t.Errorf("C should be present, got %q ok=%v", tok, ok)
+	}
+}
+
+// TestTokenCache_SetExistingKeyRefreshes pins that re-Setting the same key
+// updates the token in place instead of adding a second entry.
+func TestTokenCache_SetExistingKeyRefreshes(t *testing.T) {
+	tc := newTokenCache(50*time.Minute, 5)
+	tc.Set("h", "u", "p", "tok-1")
+	tc.Set("h", "u", "p", "tok-2")
+
+	if got := len(tc.entries); got != 1 {
+		t.Fatalf("re-Set of the same key should not grow the cache index: got %d entries", got)
+	}
+	if got := tc.ll.Len(); got != 1 {
+		t.Fatalf("re-Set of the same key should not grow the LRU list: got %d elements", got)
+	}
+	if tok, ok := tc.Get("h", "u", "p"); !ok || tok != "tok-2" {
+		t.Errorf("expected the refreshed token tok-2, got %q ok=%v", tok, ok)
+	}
+}
+
+// TestTokenCache_SetPromotesExistingKey pins that re-Setting an existing key
+// also marks it most-recently-used, so a subsequently-inserted key evicts the
+// other (now least-recently-used) entry rather than the just-refreshed one.
+func TestTokenCache_SetPromotesExistingKey(t *testing.T) {
+	tc := newTokenCache(50*time.Minute, 2)
+	tc.Set("h", "u", "A", "tok-a")
+	tc.Set("h", "u", "B", "tok-b")
+
+	// Refresh A: this must promote A to MRU, leaving B least-recently-used.
+	tc.Set("h", "u", "A", "tok-a2")
+
+	// Inserting C is over cap, so the LRU entry (B) is evicted, not A.
+	tc.Set("h", "u", "C", "tok-c")
+
+	if _, ok := tc.Get("h", "u", "B"); ok {
+		t.Error("B should have been evicted after A was refreshed to MRU")
+	}
+	if tok, ok := tc.Get("h", "u", "A"); !ok || tok != "tok-a2" {
+		t.Errorf("A should survive with its refreshed token, got %q ok=%v", tok, ok)
+	}
+}
+
+// TestTokenCache_ConcurrentAccessStaysBounded runs Set/Get from many goroutines
+// (with -race) to confirm the cache stays within its cap and free of data races.
+func TestTokenCache_ConcurrentAccessStaysBounded(t *testing.T) {
+	const goroutines, perGoroutine, capacity = 8, 200, 8
+	tc := newTokenCache(50*time.Minute, capacity)
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range perGoroutine {
+				p := fmt.Sprintf("p-%d-%d", g, i)
+				tc.Set("h", "u", p, "tok")
+				tc.Get("h", "u", p)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if got := len(tc.entries); got > capacity {
+		t.Fatalf("cache exceeded cap under concurrency: got %d, want <= %d", got, capacity)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the gateway token cache DoS (#29). `TokenCache` was an unbounded `map` under a single mutex, and `Set` swept every expired entry (O(N) under the lock) on each call. In gateway mode the cache key derives from request headers, so a caller sending many distinct credentials could grow the map without bound and lengthen the sweep, stalling all gateway requests: a memory-exhaustion and lock-stall DoS.

It is now a bounded LRU over `container/list`: O(1) get/set/evict, capped at `tokenCacheMaxEntries` (4096), with lazy TTL expiry on `Get` and least-recently-used eviction on overflow. The whole-map sweep is removed, so memory is fixed and the write path holds the lock only for O(1) work. The public API (`NewTokenCache`, `Get`, `Set`) is unchanged, so `gatewayServer` is untouched.

While here, `cacheKey` (a SHA-256 over the attacker-influenced password header) is now computed before taking the lock in both `Get` and `Set`. Hashing it under the global mutex was itself a lock-stall vector of the same class #29 targets; `cacheKey` is pure, so it moves out with no behavior change.

## Notes

- **Eviction ceiling:** with more than 4096 distinct concurrently-active credential sets, a still-valid cached token can be LRU-evicted, forcing one extra login (the miss path re-logs in and re-caches). This is graceful degradation, not a break, and the cap sits far above any legitimate deployment's distinct-credential count.
- Expired entries are now reclaimed lazily (on `Get`) or via eviction rather than by a proactive sweep; memory stays strictly bounded either way.

## Related Issues

Closes #29. Related token-cache lifecycle work: #5 (logout-on-eviction can build on this eviction hook).

## Test Plan

- [x] `go test -race ./...` passes (9 TokenCache tests including a concurrent bounded test and the gateway password-pinning test)
- [x] `golangci-lint run` clean
- [x] `TestTokenCache_BoundedToMaxEntries`: 100 distinct keys into a cap-3 cache end at exactly 3, list and map in sync
- [x] `TestTokenCache_EvictsLeastRecentlyUsed` / `TestTokenCache_SetPromotesExistingKey`: LRU order respected on both `Get` and re-`Set`
- [x] `TestTokenCache_Expired`: lazy expiry clears both the map and the list
- [x] `TestTokenCache_ConcurrentAccessStaysBounded`: bounded under 8-goroutine contention with `-race`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token cache now operates with a configurable maximum capacity, preventing unbounded memory growth in high-volume scenarios.
  * Enhanced automatic cleanup mechanism for expired token entries, improving overall resource efficiency.
  * Increased reliability and stability when handling concurrent access through improved cache eviction strategy and better entry management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->