### PR TITLE
feat: log out cached gateway sessions on graceful shutdown (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Enable it with `AUTH_MODE=gateway` alongside `MCP_TRANSPORT=http`. In this mode,
 
 Acquired session tokens are cached for 50 minutes per (host, username) pair to avoid repeated logins.
 
+On graceful shutdown (SIGINT/SIGTERM) the server logs out the Centreon sessions it created so they do not linger on the server until their idle timeout, and it waits for those logout calls to finish before exiting. Shutdown therefore takes a little longer than before, up to roughly 25 seconds if a Centreon host is slow or unreachable, so allow for this in your orchestrator's stop grace period (for example Kubernetes `terminationGracePeriodSeconds`).
+
 ### Host allowlist
 
 By default gateway mode connects to whatever `X-Centreon-Host` a caller supplies, so an exposed endpoint can be used as an SSRF or open-proxy primitive. Set `CENTREON_ALLOWED_HOSTS` to a comma-separated list of permitted host URLs to restrict this; requests whose `X-Centreon-Host` does not match an entry exactly are rejected. When the variable is unset or empty, behavior is unchanged (any host is accepted) and the server logs a warning at startup. Matching is exact and case-sensitive, so list each host URL as callers send it.

--- a/config.go
+++ b/config.go
@@ -62,7 +62,7 @@ func LoadConfig() (Config, error) {
 	}
 
 	switch cfg.AuthMode {
-	case "env", "gateway":
+	case authModeEnv, authModeGateway:
 	default:
 		return Config{}, fmt.Errorf("invalid AUTH_MODE value %q: expected env/gateway", cfg.AuthMode)
 	}

--- a/server.go
+++ b/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
 	"github.com/tphakala/centreon-mcp-go/tools"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -28,9 +29,20 @@ const (
 	shutdownTimeout   = 15 * time.Second
 	tokenCacheTTL     = 50 * time.Minute
 	selfSignedTimeout = 30 * time.Second
-	authModeEnv       = "env"
-	transportStdio    = "stdio"
-	transportHTTP     = "http"
+
+	authModeEnv     = "env"
+	authModeGateway = "gateway"
+	transportStdio  = "stdio"
+	transportHTTP   = "http"
+
+	// shutdownLogoutTimeout bounds the best-effort logout of Centreon sessions on
+	// graceful shutdown (both the env-mode shared client and the gateway token
+	// cache). It is a budget separate from shutdownTimeout so a slow
+	// httpServer.Shutdown cannot leave the logout with an already-expired context.
+	shutdownLogoutTimeout = 10 * time.Second
+	// gatewayLogoutConcurrency caps how many session logouts run at once during
+	// the shutdown drain, so a large cache does not open thousands of sockets.
+	gatewayLogoutConcurrency = 16
 )
 
 // buildServer creates an MCP server with all tools registered.
@@ -181,24 +193,41 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 		IdleTimeout:       idleTimeout,
 	}
 
+	shutdownDone := make(chan struct{})
 	go func() {
+		defer close(shutdownDone)
 		<-ctx.Done()
 		shutdownCtx, cancelShutdown := context.WithTimeout(context.WithoutCancel(ctx), shutdownTimeout)
 		defer cancelShutdown()
 		_ = httpServer.Shutdown(shutdownCtx)
 
+		// Best-effort session logout runs on a budget separate from Shutdown's, so a
+		// slow Shutdown cannot leave the logout with an already-expired context. Both
+		// modes use it, so the two paths stay consistent. Shutdown has waited only up
+		// to shutdownTimeout; if it timed out, a straggler request may still hold a
+		// cached token, but the process is exiting, so logging it out is acceptable.
+		logoutCtx, cancelLogout := context.WithTimeout(context.WithoutCancel(ctx), shutdownLogoutTimeout)
+		defer cancelLogout()
+
 		if sharedClient != nil && cfg.Token == "" {
-			_ = sharedClient.Logout(shutdownCtx)
+			_ = sharedClient.Logout(logoutCtx)
 			logger.Info("centreon client logged out")
+		}
+		if tokenCache != nil {
+			drainAndLogout(logoutCtx, tokenCache, cfg, logger, httpClient)
 		}
 	}()
 
 	logger.Info("centreon-mcp-go HTTP server listening", "addr", addr, "authMode", cfg.AuthMode)
-	if err := httpServer.ListenAndServe(); errors.Is(err, http.ErrServerClosed) {
-		return nil
-	} else {
+	err := httpServer.ListenAndServe()
+	if !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
+	// ListenAndServe returns ErrServerClosed as soon as Shutdown is *called*, not
+	// when it completes. Wait for the shutdown goroutine so in-flight requests are
+	// drained and cached sessions are logged out before the process exits.
+	<-shutdownDone
+	return nil
 }
 
 // gatewayServer creates a per-request MCP server from gateway headers.
@@ -271,4 +300,57 @@ func hostAllowed(host string, allowed []string) bool {
 		return true
 	}
 	return slices.Contains(allowed, host)
+}
+
+// drainAndLogout empties the gateway token cache and logs out each cached
+// Centreon session. It runs only during graceful shutdown, after
+// httpServer.Shutdown has returned. Shutdown has waited up to shutdownTimeout for
+// in-flight handlers; if it did not time out, no request still holds any of these
+// tokens and logging them out cannot break a live request. Logouts run
+// concurrently, bounded by gatewayLogoutConcurrency and by ctx; once ctx is done
+// the loop stops spawning further attempts that would only fail immediately.
+func drainAndLogout(ctx context.Context, tc *TokenCache, cfg *Config, logger *slog.Logger, httpClient *http.Client) {
+	tokens := tc.Drain()
+	if len(tokens) == 0 {
+		return
+	}
+
+	var g errgroup.Group
+	g.SetLimit(gatewayLogoutConcurrency)
+	for _, ct := range tokens {
+		if ctx.Err() != nil {
+			break
+		}
+		g.Go(func() error {
+			logoutCachedToken(ctx, ct.host, ct.token, cfg, logger, httpClient)
+			return nil
+		})
+	}
+	_ = g.Wait()
+	logger.Info("gateway: token cache drained", "count", len(tokens))
+}
+
+// logoutCachedToken best-effort invalidates a single cached gateway session by
+// building a token-authenticated client for its host and calling Logout, which
+// sends the token as X-AUTH-TOKEN to the Centreon logout endpoint. Failures are
+// logged at debug and swallowed: shutdown cleanup must never fail the process.
+// The cleanup client is built WITHOUT the shared logger on purpose: the centreon
+// client logs every failed request at Error, so on a cancelled or failing
+// shutdown logout it would emit dependency-layer Error noise that contradicts
+// this function's own debug-and-swallow handling.
+func logoutCachedToken(ctx context.Context, host, token string, cfg *Config, logger *slog.Logger, httpClient *http.Client) {
+	if token == "" {
+		return
+	}
+	gwCfg := &Config{Host: host, Token: token, AllowSelfSigned: cfg.AllowSelfSigned}
+	client, err := newCentreonClient(host, gwCfg, nil, httpClient)
+	if err != nil {
+		logger.Debug("gateway: failed to build client for token logout", "host", host, "error", err)
+		return
+	}
+	if err := client.Logout(ctx); err != nil {
+		logger.Debug("gateway: token logout failed", "host", host, "error", err)
+		return
+	}
+	logger.Debug("gateway: logged out cached token", "host", host)
 }

--- a/server.go
+++ b/server.go
@@ -193,34 +193,24 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 		IdleTimeout:       idleTimeout,
 	}
 
+	// serveCtx lets the shutdown goroutine run cleanup on a ListenAndServe startup
+	// error (e.g. a failed bind) as well as on a signal. In env mode the shared
+	// client has already logged in by this point, so that session must still be
+	// logged out even if the listener never comes up.
+	serveCtx, cancelServe := context.WithCancel(ctx)
+	defer cancelServe()
+
 	shutdownDone := make(chan struct{})
-	go func() {
-		defer close(shutdownDone)
-		<-ctx.Done()
-		shutdownCtx, cancelShutdown := context.WithTimeout(context.WithoutCancel(ctx), shutdownTimeout)
-		defer cancelShutdown()
-		_ = httpServer.Shutdown(shutdownCtx)
-
-		// Best-effort session logout runs on a budget separate from Shutdown's, so a
-		// slow Shutdown cannot leave the logout with an already-expired context. Both
-		// modes use it, so the two paths stay consistent. Shutdown has waited only up
-		// to shutdownTimeout; if it timed out, a straggler request may still hold a
-		// cached token, but the process is exiting, so logging it out is acceptable.
-		logoutCtx, cancelLogout := context.WithTimeout(context.WithoutCancel(ctx), shutdownLogoutTimeout)
-		defer cancelLogout()
-
-		if sharedClient != nil && cfg.Token == "" {
-			_ = sharedClient.Logout(logoutCtx)
-			logger.Info("centreon client logged out")
-		}
-		if tokenCache != nil {
-			drainAndLogout(logoutCtx, tokenCache, cfg, logger, httpClient)
-		}
-	}()
+	go gracefulShutdown(serveCtx, httpServer, sharedClient, tokenCache, cfg, logger, httpClient, shutdownDone)
 
 	logger.Info("centreon-mcp-go HTTP server listening", "addr", addr, "authMode", cfg.AuthMode)
 	err := httpServer.ListenAndServe()
 	if !errors.Is(err, http.ErrServerClosed) {
+		// A startup error (e.g. a failed bind) returns here without ctx being
+		// cancelled. Signal the shutdown goroutine so it still runs cleanup (an
+		// env-mode client may already be logged in), wait for it, then return err.
+		cancelServe()
+		<-shutdownDone
 		return err
 	}
 	// ListenAndServe returns ErrServerClosed as soon as Shutdown is *called*, not
@@ -228,6 +218,39 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 	// drained and cached sessions are logged out before the process exits.
 	<-shutdownDone
 	return nil
+}
+
+// gracefulShutdown waits for serveCtx to be cancelled (a signal or a startup
+// error), shuts the HTTP server down, then logs out the Centreon sessions the
+// server holds: the env-mode shared client or every session in the gateway token
+// cache. It closes done when finished so runHTTP can wait for cleanup before
+// returning.
+func gracefulShutdown(serveCtx context.Context, httpServer *http.Server, sharedClient *centreon.Client, tokenCache *TokenCache, cfg *Config, logger *slog.Logger, httpClient *http.Client, done chan<- struct{}) {
+	defer close(done)
+	<-serveCtx.Done()
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.WithoutCancel(serveCtx), shutdownTimeout)
+	defer cancelShutdown()
+	_ = httpServer.Shutdown(shutdownCtx)
+
+	// Best-effort session logout runs on a budget separate from Shutdown's, so a
+	// slow Shutdown cannot leave the logout with an already-expired context. Both
+	// modes use it, so the two paths stay consistent. Shutdown has waited only up to
+	// shutdownTimeout; if it timed out, a straggler request may still hold a cached
+	// token, but the process is exiting, so logging it out is acceptable.
+	logoutCtx, cancelLogout := context.WithTimeout(context.WithoutCancel(serveCtx), shutdownLogoutTimeout)
+	defer cancelLogout()
+
+	if sharedClient != nil && cfg.Token == "" {
+		if err := sharedClient.Logout(logoutCtx); err != nil {
+			logger.Debug("centreon client logout failed", "error", err)
+		} else {
+			logger.Info("centreon client logged out")
+		}
+	}
+	if tokenCache != nil {
+		drainAndLogout(logoutCtx, tokenCache, cfg, logger, httpClient)
+	}
 }
 
 // gatewayServer creates a per-request MCP server from gateway headers.
@@ -322,7 +345,7 @@ func drainAndLogout(ctx context.Context, tc *TokenCache, cfg *Config, logger *sl
 			break
 		}
 		g.Go(func() error {
-			logoutCachedToken(ctx, ct.host, ct.token, cfg, logger, httpClient)
+			logoutCachedToken(ctx, ct.Host, ct.Token, cfg, logger, httpClient)
 			return nil
 		})
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -263,6 +263,54 @@ func TestRunHTTP_GatewayLogsOutCachedSessionsOnShutdown(t *testing.T) {
 	}
 }
 
+// TestRunHTTP_LogsOutEnvClientOnBindError pins that when the HTTP listener fails
+// to start, runHTTP still logs out an env-mode client that already logged in at
+// startup (rather than leaking that Centreon session) and returns the bind error.
+func TestRunHTTP_LogsOutEnvClientOnBindError(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var logouts atomic.Int32
+	fakeMux := http.NewServeMux()
+	fakeMux.HandleFunc("POST /centreon/api/latest/login", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"security": map[string]any{"token": "tok-env"}})
+	})
+	fakeMux.HandleFunc("GET /centreon/api/latest/logout", func(w http.ResponseWriter, _ *http.Request) {
+		logouts.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	fake := httptest.NewServer(fakeMux)
+	defer fake.Close()
+
+	// Hold a port open so runHTTP's ListenAndServe fails to bind it.
+	var lc net.ListenConfig
+	occupied, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer func() { _ = occupied.Close() }()
+	addr, ok := occupied.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener address is not *net.TCPAddr: %T", occupied.Addr())
+	}
+
+	cfg := &Config{
+		Host:      fake.URL,
+		Username:  "admin",
+		Password:  "secret",
+		Transport: transportHTTP,
+		AuthMode:  authModeEnv,
+		HTTPHost:  "127.0.0.1",
+		HTTPPort:  addr.Port,
+	}
+
+	if err := runHTTP(t.Context(), cfg, logger, nil); err == nil {
+		t.Fatal("runHTTP should return the bind error, got nil")
+	}
+	if got := logouts.Load(); got != 1 {
+		t.Errorf("env client should be logged out on bind error, got %d logouts", got)
+	}
+}
+
 // freePort reserves an ephemeral TCP port and releases it, returning the number
 // so runHTTP can bind it. A small TOCTOU window is acceptable for a local test.
 func freePort(t *testing.T) int {

--- a/server_test.go
+++ b/server_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -74,6 +79,230 @@ func TestGatewayServer_HostAllowlist(t *testing.T) {
 			t.Error("expected non-nil server when allowlist is empty, got nil")
 		}
 	})
+}
+
+// TestLogoutCachedToken_SendsTokenToLogoutEndpoint pins that logoutCachedToken
+// invalidates a specific Centreon session: it must call GET /logout with the
+// cached token in the X-AUTH-TOKEN header (the client sends its stored token),
+// so the right server session is torn down.
+func TestLogoutCachedToken_SendsTokenToLogoutEndpoint(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var logoutCount atomic.Int32
+	var gotToken atomic.Value
+	gotToken.Store("")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/logout", func(w http.ResponseWriter, r *http.Request) {
+		logoutCount.Add(1)
+		gotToken.Store(r.Header.Get("X-AUTH-TOKEN"))
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	logoutCachedToken(t.Context(), srv.URL, "tok-xyz", &Config{}, logger, nil)
+
+	if n := logoutCount.Load(); n != 1 {
+		t.Fatalf("expected exactly 1 logout call, got %d", n)
+	}
+	if tok, _ := gotToken.Load().(string); tok != "tok-xyz" {
+		t.Errorf("logout must send the cached token as X-AUTH-TOKEN, got %q", tok)
+	}
+}
+
+// TestDrainAndLogout_LogsOutEveryCachedTokenAndEmptiesCache pins the #5 shutdown
+// behaviour end to end: every token in the cache is logged out on the Centreon
+// server and the cache is left empty.
+func TestDrainAndLogout_LogsOutEveryCachedTokenAndEmptiesCache(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/logout", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen[r.Header.Get("X-AUTH-TOKEN")] = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cache := newTokenCache(50*time.Minute, 10)
+	cache.Set(srv.URL, "admin", "p1", "tok-1")
+	cache.Set(srv.URL, "admin", "p2", "tok-2")
+	cache.Set(srv.URL, "admin", "p3", "tok-3")
+
+	drainAndLogout(t.Context(), cache, &Config{}, logger, nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, tok := range []string{"tok-1", "tok-2", "tok-3"} {
+		if !seen[tok] {
+			t.Errorf("token %q was not logged out", tok)
+		}
+	}
+	if n := len(cache.entries); n != 0 {
+		t.Errorf("drainAndLogout should empty the cache, %d entries remain", n)
+	}
+}
+
+// TestDrainAndLogout_SwallowsLogoutFailuresAndEmptiesCache pins the best-effort
+// contract: when the Centreon logout endpoint fails, drainAndLogout still
+// attempts every cached session, still empties the cache, and never fails. A
+// failing logout must not abort the remaining ones.
+func TestDrainAndLogout_SwallowsLogoutFailuresAndEmptiesCache(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var attempts atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/logout", func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cache := newTokenCache(50*time.Minute, 10)
+	cache.Set(srv.URL, "admin", "p1", "tok-1")
+	cache.Set(srv.URL, "admin", "p2", "tok-2")
+	cache.Set(srv.URL, "admin", "p3", "tok-3")
+
+	drainAndLogout(t.Context(), cache, &Config{}, logger, nil)
+
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("every cached session should be attempted despite failures: got %d, want 3", got)
+	}
+	if n := len(cache.entries); n != 0 {
+		t.Errorf("drainAndLogout should empty the cache even when logouts fail, %d entries remain", n)
+	}
+}
+
+// TestRunHTTP_GatewayLogsOutCachedSessionsOnShutdown is the end-to-end guard for
+// issue #5: it starts the real HTTP server in gateway mode, drives one gateway
+// request that logs in and caches a token, cancels the context, and asserts that
+// runHTTP does not return until the cached Centreon session has been logged out.
+// This pins the shutdownDone wait: without it, runHTTP would return before the
+// drain completes and the logout would be lost.
+func TestRunHTTP_GatewayLogsOutCachedSessionsOnShutdown(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var logins, logouts atomic.Int32
+	var loggedOutToken atomic.Value
+	loggedOutToken.Store("")
+
+	fakeMux := http.NewServeMux()
+	fakeMux.HandleFunc("POST /centreon/api/latest/login", func(w http.ResponseWriter, _ *http.Request) {
+		n := logins.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"security": map[string]any{"token": fmt.Sprintf("tok-%d", n)}})
+	})
+	fakeMux.HandleFunc("GET /centreon/api/latest/logout", func(w http.ResponseWriter, r *http.Request) {
+		logouts.Add(1)
+		loggedOutToken.Store(r.Header.Get("X-AUTH-TOKEN"))
+		w.WriteHeader(http.StatusOK)
+	})
+	fake := httptest.NewServer(fakeMux)
+	defer fake.Close()
+
+	port := freePort(t)
+	cfg := &Config{
+		Host:      fake.URL, // required field; unused in gateway mode (host comes from headers)
+		Transport: transportHTTP,
+		AuthMode:  authModeGateway,
+		HTTPHost:  "127.0.0.1",
+		HTTPPort:  port,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- runHTTP(ctx, cfg, logger, nil) }()
+
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+	waitForHealth(t, base+"/health")
+
+	// One gateway request: the gateway logs in on the fake Centreon and caches the
+	// token. The login runs synchronously while building the per-request server.
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build /mcp request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("X-Centreon-Host", fake.URL)
+	req.Header.Set("X-Centreon-Username", "admin")
+	req.Header.Set("X-Centreon-Password", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /mcp: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got := logins.Load(); got != 1 {
+		t.Fatalf("gateway request should trigger exactly one login, got %d", got)
+	}
+
+	// Graceful shutdown: runHTTP must not return until the drain has completed.
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runHTTP returned error on shutdown: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("runHTTP did not return within 15s after context cancel")
+	}
+
+	if got := logouts.Load(); got != 1 {
+		t.Fatalf("cached session should be logged out before runHTTP returns, got %d logouts", got)
+	}
+	if tok, _ := loggedOutToken.Load().(string); tok != "tok-1" {
+		t.Errorf("shutdown logout should target the cached token, got %q", tok)
+	}
+}
+
+// freePort reserves an ephemeral TCP port and releases it, returning the number
+// so runHTTP can bind it. A small TOCTOU window is acceptable for a local test.
+func freePort(t *testing.T) int {
+	t.Helper()
+	var lc net.ListenConfig
+	l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve free port: %v", err)
+	}
+	addr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = l.Close()
+		t.Fatalf("listener address is not *net.TCPAddr: %T", l.Addr())
+	}
+	port := addr.Port
+	_ = l.Close()
+	return port
+}
+
+// waitForHealth polls the /health endpoint until it returns 200 or the deadline
+// elapses, so the test only proceeds once runHTTP is actually serving.
+func waitForHealth(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: time.Second}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+		if err != nil {
+			t.Fatalf("build health request: %v", err)
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("server did not become healthy within 10s")
 }
 
 // TestGatewayServer_TokenCachePinsPassword is an end-to-end regression guard

--- a/token_cache.go
+++ b/token_cache.go
@@ -16,6 +16,7 @@ import (
 const tokenCacheMaxEntries = 4096
 
 type tokenEntry struct {
+	host    string // Centreon host this token authenticates against; needed to log the session out (the cache key is a hash, so host is not recoverable from it)
 	token   string
 	expires time.Time
 	el      *list.Element // position in ll; el.Value holds the map key (string)
@@ -119,7 +120,7 @@ func (c *TokenCache) Set(host, username, password, token string) {
 		c.removeOldest()
 	}
 	el := c.ll.PushFront(key)
-	c.entries[key] = &tokenEntry{token: token, expires: expires, el: el}
+	c.entries[key] = &tokenEntry{host: host, token: token, expires: expires, el: el}
 }
 
 // remove drops a known key/entry pair from both the list and the index.
@@ -139,4 +140,30 @@ func (c *TokenCache) removeOldest() {
 	key, _ := back.Value.(string)
 	c.ll.Remove(back)
 	delete(c.entries, key)
+}
+
+// cachedToken is a (host, token) pair returned by Drain. The caller uses it to
+// log the token's Centreon session out; the host is carried explicitly because
+// the cache key is a one-way hash and cannot yield it back.
+type cachedToken struct {
+	host  string
+	token string
+}
+
+// Drain removes every entry and returns their (host, token) pairs, then leaves
+// the cache empty. Entries whose TTL has already passed are included on purpose:
+// their Centreon session can outlive the cache TTL, so a graceful shutdown must
+// still attempt to log them out. Drain performs no I/O; the caller does the
+// logouts outside the lock.
+func (c *TokenCache) Drain() []cachedToken {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	drained := make([]cachedToken, 0, len(c.entries))
+	for _, entry := range c.entries {
+		drained = append(drained, cachedToken{host: entry.host, token: entry.token})
+	}
+	c.ll.Init()
+	c.entries = make(map[string]*tokenEntry)
+	return drained
 }

--- a/token_cache.go
+++ b/token_cache.go
@@ -15,6 +15,13 @@ import (
 // deployments have far fewer distinct credential sets than this.
 const tokenCacheMaxEntries = 4096
 
+// maxCachedHostLen bounds the length of a host string the cache will retain. In
+// gateway mode host comes from an attacker-influenced request header, so caching
+// it adds an attacker-influenced SIZE dimension on top of the entry COUNT that
+// tokenCacheMaxEntries already caps. This ceiling keeps per-entry size bounded
+// too; a real Centreon base URL is far shorter than this.
+const maxCachedHostLen = 2048
+
 type tokenEntry struct {
 	host    string // Centreon host this token authenticates against; needed to log the session out (the cache key is a hash, so host is not recoverable from it)
 	token   string
@@ -100,6 +107,13 @@ func (c *TokenCache) Get(host, username, password string) (string, bool) {
 // capacity and the key is new, the least-recently-used entry is evicted first,
 // so the cache stays within its fixed bound.
 func (c *TokenCache) Set(host, username, password, token string) {
+	// Refuse to retain an unreasonably large (attacker-influenced) host, so the
+	// bounded cache cannot be inflated in size as well as count. Such a session is
+	// simply not cached; it re-authenticates as needed and self-expires server-side.
+	if len(host) > maxCachedHostLen {
+		return
+	}
+
 	// Hash before taking the lock (see Get): the password is attacker-influenced
 	// and cacheKey is pure, so the hash must not run under the global mutex.
 	key := cacheKey(host, username, password)
@@ -142,12 +156,12 @@ func (c *TokenCache) removeOldest() {
 	delete(c.entries, key)
 }
 
-// cachedToken is a (host, token) pair returned by Drain. The caller uses it to
+// CachedToken is a (host, token) pair returned by Drain. The caller uses it to
 // log the token's Centreon session out; the host is carried explicitly because
 // the cache key is a one-way hash and cannot yield it back.
-type cachedToken struct {
-	host  string
-	token string
+type CachedToken struct {
+	Host  string
+	Token string
 }
 
 // Drain removes every entry and returns their (host, token) pairs, then leaves
@@ -155,13 +169,13 @@ type cachedToken struct {
 // their Centreon session can outlive the cache TTL, so a graceful shutdown must
 // still attempt to log them out. Drain performs no I/O; the caller does the
 // logouts outside the lock.
-func (c *TokenCache) Drain() []cachedToken {
+func (c *TokenCache) Drain() []CachedToken {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	drained := make([]cachedToken, 0, len(c.entries))
+	drained := make([]CachedToken, 0, len(c.entries))
 	for _, entry := range c.entries {
-		drained = append(drained, cachedToken{host: entry.host, token: entry.token})
+		drained = append(drained, CachedToken{Host: entry.host, Token: entry.token})
 	}
 	c.ll.Init()
 	c.entries = make(map[string]*tokenEntry)

--- a/token_cache_test.go
+++ b/token_cache_test.go
@@ -163,6 +163,69 @@ func TestTokenCache_SetPromotesExistingKey(t *testing.T) {
 	}
 }
 
+// TestTokenCache_DrainReturnsAllAndEmpties pins the #5 shutdown-drain support:
+// Drain returns every cached (host, token) pair so each Centreon session can be
+// logged out, and leaves the cache empty (both the index and the LRU list).
+func TestTokenCache_DrainReturnsAllAndEmpties(t *testing.T) {
+	tc := newTokenCache(50*time.Minute, 10)
+	tc.Set("https://h1", "u", "p1", "tok-1")
+	tc.Set("https://h2", "u", "p2", "tok-2")
+	tc.Set("https://h3", "u", "p3", "tok-3")
+
+	drained := tc.Drain()
+	if len(drained) != 3 {
+		t.Fatalf("Drain should return every cached entry: got %d, want 3", len(drained))
+	}
+
+	got := make(map[string]string, len(drained))
+	for _, ct := range drained {
+		got[ct.host] = ct.token
+	}
+	want := map[string]string{"https://h1": "tok-1", "https://h2": "tok-2", "https://h3": "tok-3"}
+	for h, tok := range want {
+		if got[h] != tok {
+			t.Errorf("drained token for %s = %q, want %q", h, got[h], tok)
+		}
+	}
+
+	if n := len(tc.entries); n != 0 {
+		t.Errorf("Drain should empty the entry index: %d remain", n)
+	}
+	if n := tc.ll.Len(); n != 0 {
+		t.Errorf("Drain should empty the LRU list: %d remain", n)
+	}
+	if _, ok := tc.Get("https://h1", "u", "p1"); ok {
+		t.Error("Get should miss after Drain")
+	}
+}
+
+// TestTokenCache_DrainIncludesExpiredEntries pins that Drain returns entries
+// whose cache TTL has already passed but that have not yet been lazily dropped.
+// The Centreon server session can outlive the cache TTL (activity resets its
+// idle timer), so a graceful shutdown must still attempt to log these out.
+func TestTokenCache_DrainIncludesExpiredEntries(t *testing.T) {
+	// A negative TTL makes the entry already expired the instant it is stored.
+	tc := newTokenCache(-time.Minute, 10)
+	tc.Set("https://h1", "u", "p1", "tok-expired")
+
+	drained := tc.Drain()
+	if len(drained) != 1 {
+		t.Fatalf("Drain must include TTL-expired entries: got %d, want 1", len(drained))
+	}
+	if drained[0].host != "https://h1" || drained[0].token != "tok-expired" {
+		t.Errorf("unexpected drained entry: %+v", drained[0])
+	}
+}
+
+// TestTokenCache_DrainEmptyReturnsNothing pins that draining an empty cache is a
+// safe no-op that returns no work.
+func TestTokenCache_DrainEmptyReturnsNothing(t *testing.T) {
+	tc := newTokenCache(50*time.Minute, 10)
+	if drained := tc.Drain(); len(drained) != 0 {
+		t.Fatalf("Drain on an empty cache should return nothing, got %d", len(drained))
+	}
+}
+
 // TestTokenCache_ConcurrentAccessStaysBounded runs Set/Get from many goroutines
 // (with -race) to confirm the cache stays within its cap and free of data races.
 func TestTokenCache_ConcurrentAccessStaysBounded(t *testing.T) {

--- a/token_cache_test.go
+++ b/token_cache_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -179,7 +180,7 @@ func TestTokenCache_DrainReturnsAllAndEmpties(t *testing.T) {
 
 	got := make(map[string]string, len(drained))
 	for _, ct := range drained {
-		got[ct.host] = ct.token
+		got[ct.Host] = ct.Token
 	}
 	want := map[string]string{"https://h1": "tok-1", "https://h2": "tok-2", "https://h3": "tok-3"}
 	for h, tok := range want {
@@ -212,8 +213,31 @@ func TestTokenCache_DrainIncludesExpiredEntries(t *testing.T) {
 	if len(drained) != 1 {
 		t.Fatalf("Drain must include TTL-expired entries: got %d, want 1", len(drained))
 	}
-	if drained[0].host != "https://h1" || drained[0].token != "tok-expired" {
+	if drained[0].Host != "https://h1" || drained[0].Token != "tok-expired" {
 		t.Errorf("unexpected drained entry: %+v", drained[0])
+	}
+}
+
+// TestTokenCache_SkipsOverlongHost pins the defensive size bound: an
+// unreasonably large (attacker-influenced) host is not retained, so the bounded
+// cache cannot be inflated in per-entry size, only in count.
+func TestTokenCache_SkipsOverlongHost(t *testing.T) {
+	tc := newTokenCache(50*time.Minute, 10)
+
+	longHost := "https://" + strings.Repeat("a", maxCachedHostLen)
+	tc.Set(longHost, "u", "p", "tok")
+
+	if _, ok := tc.Get(longHost, "u", "p"); ok {
+		t.Error("an overlong host must not be cached")
+	}
+	if n := len(tc.entries); n != 0 {
+		t.Errorf("overlong host should leave the cache empty, got %d entries", n)
+	}
+
+	// A normal host is unaffected.
+	tc.Set("https://ok.example.com", "u", "p", "tok")
+	if _, ok := tc.Get("https://ok.example.com", "u", "p"); !ok {
+		t.Error("a normal host should still be cached")
 	}
 }
 


### PR DESCRIPTION
## Summary

In gateway mode the HTTP server built a per-request Centreon client from `X-Centreon-*` headers, logged in on a cache miss, and cached the token, but it never called `Logout`. Sessions accumulated on the Centreon server until their idle timeout (issue #5).

The centreon client's `Logout` sends the token as `X-AUTH-TOKEN` and invalidates the shared server session for that token value, so it breaks any client still holding the token. That rules out the two obvious designs: per-request logout would defeat the 50-minute token cache (a cache hit reuses the token), and runtime eviction/expiry logout would race an in-flight request that got a cache hit just before eviction. The one race-free point is graceful shutdown, after `httpServer.Shutdown` has waited for in-flight handlers: drain the token cache and log out every cached session with a bounded `errgroup`.

`runHTTP` now waits on a `shutdownDone` channel before returning. `ListenAndServe` returns `ErrServerClosed` as soon as `Shutdown` is called (not when it finishes), so previously the process could exit before the cleanup goroutine ran; the wait fixes that and, as a side effect, makes the pre-existing env-mode shared-client logout on shutdown reliable too.

Runtime sessions stay bounded by the token cache (cap 4096, LRU, from #29) and self-expire on the server, so this deliberately does not attempt runtime reclamation; a follow-up tracks a delayed eviction reaper for that.

## Changes

- `TokenCache.Drain()` returns every cached `(host, token)` pair, including TTL-expired ones whose Centreon session may still be alive, and empties the cache. `tokenEntry` now records the host (the cache key is a one-way hash, so the host must be carried explicitly to rebuild a client for logout).
- Shutdown drains the cache and logs out each session concurrently, bounded by a small limit and by a logout budget that is separate from the `Shutdown` budget so a slow `Shutdown` cannot starve the logouts. Both HTTP logout paths (env shared client and gateway drain) share that budget.
- The cleanup client is built without the shared logger, so a cancelled or failed shutdown logout does not emit dependency-layer Error noise (same class as #33).

## Test plan

- [x] `go test -race ./...` green, including a new integration test that starts the real HTTP server in gateway mode, drives one gateway request, cancels the context, and asserts the cached session is logged out before `runHTTP` returns (pins the `shutdownDone` wait).
- [x] Unit tests for `Drain` (returns all incl. expired, empties cache), `logoutCachedToken` (sends the token as `X-AUTH-TOKEN`), and `drainAndLogout` (logs out every session, swallows failures).
- [x] `golangci-lint run ./...` clean, `gofmt` clean, `go vet` clean.
- [x] Verified end to end against a fake Centreon server: one cached login, SIGTERM, exactly one logout of the cached token, clean process exit.

Fixes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graceful shutdown handling that logs out created Centreon sessions before the server exits.
  * Shutdown now waits for cleanup to complete, with an exit time of up to approximately 25 seconds.
  * Cached sessions are safely drained and removed during shutdown.

* **Bug Fixes**
  * Prevented oversized host values from being stored in the session cache.
  * Improved cleanup resilience by continuing logout attempts when individual requests fail.

* **Documentation**
  * Documented the server’s graceful shutdown behavior and timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->