### PR TITLE
fix: block cross-host redirects so X-AUTH-TOKEN cannot leak (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Exposes 88 tools covering real-time monitoring, host and service configuration, 
 - **Structured JSON logging** via `log/slog` with configurable levels
 - **Gateway mode with token cache**: per-request Centreon credentials via HTTP headers, with a 50-minute token cache to avoid repeated logins
 - **Self-signed certificate support**: opt-in via `CENTREON_ALLOW_SELF_SIGNED`
+- **Cross-host redirect protection**: the Centreon session token (`X-AUTH-TOKEN`) is never forwarded across an HTTP redirect to a different host, preventing credential leakage (CWE-522)
 
 ## Requirements
 
@@ -69,6 +70,8 @@ All configuration is via environment variables.
 | `LOG_LEVEL`                 | No       | `info`      | Log level: `debug`, `info`, `warn`, or `error`               |
 
 \* Either `CENTREON_TOKEN` or both `CENTREON_USERNAME` and `CENTREON_PASSWORD` must be set. In `gateway` auth mode, credentials are supplied per-request via headers instead.
+
+> **Note on redirects:** to protect the session token, the server never follows an HTTP redirect to a different host. Point `CENTREON_HOST` (and, in gateway mode, `X-Centreon-Host`) at the URL that serves the Centreon API directly. A host that redirects to a different hostname (for example an apex-to-`www` or a vanity-to-backend redirect) makes requests fail with `refusing cross-host redirect`; use the final resolved URL instead. Same-host redirects, including an `http` to `https` upgrade, are still followed.
 
 ## Usage with Claude Code
 

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -28,7 +29,12 @@ const (
 	idleTimeout       = 120 * time.Second
 	shutdownTimeout   = 15 * time.Second
 	tokenCacheTTL     = 50 * time.Minute
-	selfSignedTimeout = 30 * time.Second
+	httpClientTimeout = 30 * time.Second
+
+	// maxRedirects caps a redirect chain, matching net/http's default policy that
+	// noCrossHostRedirect replaces: installing a custom CheckRedirect removes the
+	// stdlib's own 10-redirect cap, so the policy must re-impose one.
+	maxRedirects = 10
 
 	authModeEnv     = "env"
 	authModeGateway = "gateway"
@@ -55,23 +61,68 @@ func buildServer(client *centreon.Client, logger *slog.Logger) *mcp.Server {
 	return s
 }
 
-// selfSignedHTTPClient creates a reusable HTTP client that accepts self-signed certificates.
-// Called once at startup; the returned client is shared across all requests.
-func selfSignedHTTPClient() (*http.Client, error) {
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return nil, fmt.Errorf("unexpected default transport type")
+// noCrossHostRedirect is an http.Client CheckRedirect policy that refuses any
+// redirect whose target host differs from the original request's host. The
+// centreon client sets X-AUTH-TOKEN on every request, and Go does NOT strip
+// custom headers on cross-origin redirects (unlike Authorization or Cookie), so
+// without this guard a compromised or misconfigured Centreon host could redirect
+// an API call to another origin and leak the session token (CWE-522).
+//
+// The comparison anchors on via[0] (the original request), so every hop must
+// stay on the original host; a chain cannot be walked off-host one same-looking
+// hop at a time. It compares Hostname() only, ignoring scheme and port, so
+// same-host behaviours such as trailing-slash normalisation and an http->https
+// upgrade keep working. The match is an exact hostname (case-insensitive),
+// intentionally stricter than net/http's domain-or-subdomain rule: a redirect to
+// a different subdomain is refused (fail-closed for a credential header). A
+// same-host https->http downgrade is still allowed here; cleartext transport is
+// out of scope for this fix and owned by issue #28.
+//
+// net/http invokes CheckRedirect only while following a redirect, so via always
+// holds at least the original request; the len(via)==0 guard is defensive
+// against any future direct caller.
+func noCrossHostRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
 	}
-	transport := defaultTransport.Clone()
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // user-requested self-signed cert support
-	return &http.Client{
-		Timeout:   selfSignedTimeout,
-		Transport: transport,
-	}, nil
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+	origin := via[0].URL.Hostname()
+	if target := req.URL.Hostname(); !strings.EqualFold(target, origin) {
+		return fmt.Errorf("refusing cross-host redirect from %q to %q", origin, target)
+	}
+	return nil
 }
 
-// newCentreonClient creates a centreon.Client with the given config.
-// httpClient may be nil; if non-nil it is used for all HTTP requests (e.g. self-signed TLS).
+// newHTTPClient builds the HTTP client shared by every Centreon request. It
+// always installs noCrossHostRedirect so the X-AUTH-TOKEN header cannot leak
+// across a cross-host redirect (see that function). When allowSelfSigned is set
+// it clones http.DefaultTransport and disables TLS verification for self-signed
+// Centreon instances; cloning (rather than mutating the shared default) both
+// avoids polluting other users of http.DefaultTransport and preserves settings
+// like ForceAttemptHTTP2.
+func newHTTPClient(allowSelfSigned bool) (*http.Client, error) {
+	hc := &http.Client{
+		Timeout:       httpClientTimeout,
+		CheckRedirect: noCrossHostRedirect,
+	}
+	if allowSelfSigned {
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return nil, fmt.Errorf("unexpected default transport type")
+		}
+		transport := defaultTransport.Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // user-requested self-signed cert support
+		hc.Transport = transport
+	}
+	return hc, nil
+}
+
+// newCentreonClient creates a centreon.Client with the given config. In
+// production httpClient is always the newHTTPClient product, so the cross-host
+// redirect guard and shared timeout apply to every request; it may be nil in
+// tests, in which case the dependency's default client (no redirect guard) is used.
 func newCentreonClient(host string, cfg *Config, logger *slog.Logger, httpClient *http.Client) (*centreon.Client, error) {
 	opts := []centreon.Option{}
 	if cfg.Token != "" {
@@ -92,14 +143,13 @@ func newCentreonClient(host string, cfg *Config, logger *slog.Logger, httpClient
 func run(ctx context.Context, cfg *Config, logger *slog.Logger) error {
 	logger.Info("centreon-mcp-go starting", "version", version, "transport", cfg.Transport)
 
-	// Create self-signed HTTP client once, shared across all requests.
-	var httpClient *http.Client
-	if cfg.AllowSelfSigned {
-		var err error
-		httpClient, err = selfSignedHTTPClient()
-		if err != nil {
-			return fmt.Errorf("creating self-signed HTTP client: %w", err)
-		}
+	// One HTTP client, shared across all requests. It always installs the
+	// cross-host redirect guard (X-AUTH-TOKEN must not leak, CWE-522) and, when
+	// configured, self-signed TLS support. Building it here means every mode
+	// (stdio, env HTTP, gateway per-request, shutdown logout) gets the guard.
+	httpClient, err := newHTTPClient(cfg.AllowSelfSigned)
+	if err != nil {
+		return fmt.Errorf("creating HTTP client: %w", err)
 	}
 
 	switch cfg.Transport {

--- a/server_test.go
+++ b/server_test.go
@@ -428,3 +428,241 @@ func TestGatewayServer_TokenCachePinsPassword(t *testing.T) {
 		t.Fatalf("request 3: wrong password must force a fresh login (expected 2 total), got %d", n)
 	}
 }
+
+// --- Issue #36: cross-host redirects must not leak the X-AUTH-TOKEN header ---
+
+// TestNoCrossHostRedirect pins the redirect policy directly: redirects that stay
+// on the original request host are allowed (so trailing-slash normalisation,
+// http->https upgrade, and same-host port changes keep working), and a redirect
+// to a different host is refused. The anchor is the ORIGINAL request (via[0]),
+// not the previous hop, so a chain cannot be walked off the original host one
+// same-looking hop at a time.
+func TestNoCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	req := func(rawURL string) *http.Request {
+		return httptest.NewRequestWithContext(t.Context(), http.MethodGet, rawURL, http.NoBody)
+	}
+
+	tests := []struct {
+		name    string
+		target  string
+		via     []*http.Request
+		wantErr string // substring to find; "" means expect nil
+	}{
+		{"same host is allowed", "http://centreon.example.com/api", []*http.Request{req("http://centreon.example.com/login")}, ""},
+		{"http to https on same host is allowed", "https://centreon.example.com/api", []*http.Request{req("http://centreon.example.com/login")}, ""},
+		{"same host different port is allowed", "https://centreon.example.com:8443/api", []*http.Request{req("http://centreon.example.com:8080/login")}, ""},
+		{"host match is case-insensitive", "http://Centreon.Example.COM/api", []*http.Request{req("http://centreon.example.com/login")}, ""},
+		{"empty via is allowed defensively", "http://centreon.example.com/api", nil, ""},
+		{"different host is refused", "http://evil.example.com/api", []*http.Request{req("http://centreon.example.com/login")}, "cross-host redirect"},
+		// Discriminates the via[0] anchor from a previous-hop anchor: the last hop
+		// matches the target, so anchoring on the previous hop would WRONGLY allow
+		// this; only anchoring on the original host (via[0]) refuses it.
+		{"anchored on the original host across a hostname change", "http://mid.example.com/x", []*http.Request{req("http://centreon.example.com/"), req("http://mid.example.com/a")}, "cross-host redirect"},
+		// Host-spoof via userinfo: url.Parse puts "centreon.example.com" in the
+		// userinfo and the real host is evil.example.com. A naive raw-string or
+		// substring check on the URL would be fooled by the userinfo; Hostname()
+		// returns the real host, so the guard must still refuse.
+		{"userinfo in the target does not spoof the host", "http://centreon.example.com@evil.example.com/", []*http.Request{req("http://centreon.example.com/login")}, "cross-host redirect"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := noCrossHostRedirect(req(tt.target), tt.via)
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Errorf("noCrossHostRedirect(%s) = %v, want nil", tt.target, err)
+			case tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)):
+				t.Errorf("noCrossHostRedirect(%s) = %v, want error containing %q", tt.target, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestNoCrossHostRedirect_CapsChain pins that the policy stops a chain after
+// maxRedirects hops, matching net/http's default cap that a custom CheckRedirect
+// would otherwise remove. The target is same-host so ONLY the length cap can
+// produce the error: if the cap check is missing, the host check passes and the
+// function wrongly returns nil.
+func TestNoCrossHostRedirect_CapsChain(t *testing.T) {
+	t.Parallel()
+
+	via := make([]*http.Request, maxRedirects)
+	for i := range via {
+		via[i] = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://centreon.example.com/", http.NoBody)
+	}
+	err := noCrossHostRedirect(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://centreon.example.com/next", http.NoBody), via)
+	if err == nil || !strings.Contains(err.Error(), "stopped after") {
+		t.Errorf("noCrossHostRedirect with %d prior hops = %v, want a redirect-cap error", maxRedirects, err)
+	}
+}
+
+// TestNewHTTPClient_Wiring pins that every client the server builds carries the
+// redirect policy and the shared timeout, and that the self-signed variant
+// disables TLS verification on a cloned transport.
+func TestNewHTTPClient_Wiring(t *testing.T) {
+	t.Parallel()
+
+	plain, err := newHTTPClient(false)
+	if err != nil {
+		t.Fatalf("newHTTPClient(false): %v", err)
+	}
+	if plain.CheckRedirect == nil {
+		t.Error("plain client must set CheckRedirect so redirects are policed")
+	}
+	if plain.Timeout != httpClientTimeout {
+		t.Errorf("plain client timeout = %v, want %v", plain.Timeout, httpClientTimeout)
+	}
+
+	selfSigned, err := newHTTPClient(true)
+	if err != nil {
+		t.Fatalf("newHTTPClient(true): %v", err)
+	}
+	if selfSigned.CheckRedirect == nil {
+		t.Error("self-signed client must also set CheckRedirect")
+	}
+	transport, ok := selfSigned.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("self-signed client transport = %T, want *http.Transport", selfSigned.Transport)
+	}
+	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("self-signed client must skip TLS verification")
+	}
+}
+
+// TestNewHTTPClient_FollowsSameHostRedirect proves the policy does not
+// over-block: a same-host 302 is still followed to completion through the real
+// client newHTTPClient builds.
+func TestNewHTTPClient_FollowsSameHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/final", http.StatusFound)
+	})
+	mux.HandleFunc("/final", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	hc, err := newHTTPClient(false)
+	if err != nil {
+		t.Fatalf("newHTTPClient: %v", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/start", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatalf("same-host redirect should be followed, got error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200 after same-host redirect, got %d", resp.StatusCode)
+	}
+}
+
+// TestNewHTTPClient_BlocksCrossHostRedirect proves the token-leak vector is
+// closed end to end: a redirect to a different host is refused before the client
+// dials the target, so the X-AUTH-TOKEN header never reaches another origin.
+// other.invalid is unresolvable by RFC 2606, so the test only passes if
+// CheckRedirect rejects the hop before any dial or DNS lookup is attempted.
+func TestNewHTTPClient_BlocksCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://other.invalid/steal", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	hc, err := newHTTPClient(false)
+	if err != nil {
+		t.Fatalf("newHTTPClient: %v", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/start", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := hc.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("cross-host redirect must be refused, got nil error")
+	}
+	if !strings.Contains(err.Error(), "cross-host redirect") {
+		t.Errorf("want a cross-host redirect error, got: %v", err)
+	}
+}
+
+// TestNewHTTPClient_StopsRedirectLoop proves a same-host redirect loop is bounded
+// by the maxRedirects cap through the real client instead of spinning forever.
+func TestNewHTTPClient_StopsRedirectLoop(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/loop", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/loop", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	hc, err := newHTTPClient(false)
+	if err != nil {
+		t.Fatalf("newHTTPClient: %v", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/loop", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := hc.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("same-host redirect loop must be stopped, got nil error")
+	}
+	if !strings.Contains(err.Error(), "stopped after") {
+		t.Errorf("want a redirect-cap error, got: %v", err)
+	}
+}
+
+// TestRun_EnvLoginRefusesCrossHostRedirect pins the always-supply-client change:
+// run must build the guarded HTTP client for every mode, so an env-mode startup
+// login whose endpoint redirects to another host fails with the redirect guard
+// rather than following the redirect and leaking the credentials. The login
+// fails before any listener binds, so no port is needed.
+func TestRun_EnvLoginRefusesCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.DiscardHandler)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /centreon/api/latest/login", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://other.invalid/", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := &Config{
+		Host:      srv.URL,
+		Username:  "admin",
+		Password:  "secret",
+		Transport: transportHTTP,
+		AuthMode:  authModeEnv,
+		HTTPHost:  "127.0.0.1",
+	}
+
+	err := run(t.Context(), cfg, logger)
+	if err == nil {
+		t.Fatal("run should fail when the startup login redirects cross-host, got nil")
+	}
+	if !strings.Contains(err.Error(), "centreon login") || !strings.Contains(err.Error(), "cross-host redirect") {
+		t.Errorf("want a login error caused by the cross-host redirect guard, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Go's `http.Client` follows redirects by default and does not strip custom headers on cross-origin redirects (unlike `Authorization` or `Cookie`). The centreon-go-client sets `X-AUTH-TOKEN` on every request, so a compromised or misconfigured Centreon host that redirects an API endpoint to another origin would forward the session token to that origin (CWE-522).

This adds a `noCrossHostRedirect` `CheckRedirect` policy that refuses any redirect whose target hostname differs from the original request host. The comparison anchors on the original request (`via[0]`), so a chain cannot be walked off-host one same-looking hop at a time, and it compares `Hostname()` only, so legitimate same-host behaviour (trailing-slash normalisation, an `http` to `https` upgrade) still works. Installing a custom `CheckRedirect` removes net/http's own 10-redirect cap, so the policy re-imposes it.

The policy is built into a single `newHTTPClient` that `run()` now always supplies, so every mode gets the guard: stdio, env HTTP, gateway per-request, and shutdown logout. Previously the client was customised only for self-signed TLS and was otherwise nil, leaving the dependency's redirect-following default in place.

A same-host `https` to `http` downgrade is intentionally still allowed here; cleartext transport is a separate concern tracked in #28.

## Related issues

Closes #36. Relates to #28 (HTTPS enforcement) and #39 (dead `gwCfg.AllowSelfSigned` cleanup found during review).

## Test plan

- [x] `go test ./...` and `go test -race ./...` pass
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Unit tests for `noCrossHostRedirect`: same-host allowed (incl. `http`->`https` and port change), case-insensitive, empty-via defensive, cross-host refused, `via[0]` anchor across a hostname change, userinfo-spoofed host refused, redirect cap
- [x] End-to-end tests through the real client: same-host 302 followed, cross-host redirect refused before dial, same-host loop capped
- [x] Integration test: `run()` in env mode refuses a cross-host login redirect
- [x] Every new test verified by deleting the production line it pins and confirming it goes red