### PR TITLE
fix: reject cleartext http:// Centreon hosts by default (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ All configuration is via environment variables.
 | `CENTREON_PASSWORD`         | *        | (none)      | Password for session-based authentication                    |
 | `CENTREON_TOKEN`            | *        | (none)      | API token (alternative to username + password)               |
 | `CENTREON_ALLOW_SELF_SIGNED`| No       | `false`     | Accept self-signed TLS certificates                          |
+| `CENTREON_ALLOW_HTTP`       | No       | `false`     | Permit cleartext `http://` Centreon URLs. Off by default; `http` sends credentials unencrypted (CWE-319). |
 | `MCP_TRANSPORT`             | No       | `stdio`     | Transport mode: `stdio` or `http`                            |
 | `MCP_HTTP_PORT`             | No       | `8080`      | HTTP listen port (HTTP transport only)                       |
 | `MCP_HTTP_HOST`             | No       | `0.0.0.0`   | HTTP listen address (HTTP transport only)                    |
@@ -72,6 +73,8 @@ All configuration is via environment variables.
 \* Either `CENTREON_TOKEN` or both `CENTREON_USERNAME` and `CENTREON_PASSWORD` must be set. In `gateway` auth mode, credentials are supplied per-request via headers instead.
 
 > **Note on redirects:** to protect the session token, the server never follows an HTTP redirect to a different host. Point `CENTREON_HOST` (and, in gateway mode, `X-Centreon-Host`) at the URL that serves the Centreon API directly. A host that redirects to a different hostname (for example an apex-to-`www` or a vanity-to-backend redirect) makes requests fail with `refusing cross-host redirect`; use the final resolved URL instead. Same-host redirects, including an `http` to `https` upgrade, are still followed.
+
+> **Note on transport security:** to keep credentials off the wire, the server rejects a cleartext `http://` `CENTREON_HOST` (except in gateway mode, where it is an unused placeholder), `CENTREON_ALLOWED_HOSTS` entry, or gateway `X-Centreon-Host` value (CWE-319); use `https://`. For a trusted LAN or loopback deployment you can opt back in with `CENTREON_ALLOW_HTTP=true`, but credentials then travel unencrypted. Upgrading an existing `http://` deployment requires setting this flag; every `CENTREON_ALLOWED_HOSTS` entry must include a scheme (`https://`, or `http://` with the flag set).
 
 ## Usage with Claude Code
 
@@ -153,7 +156,7 @@ Configure your MCP client to connect to `http://localhost:8080/mcp`.
 
 Gateway mode is for multi-tenant or shared deployments where each request carries its own Centreon credentials. The server creates a per-request Centreon client authenticated with the supplied credentials.
 
-Enable it with `AUTH_MODE=gateway` alongside `MCP_TRANSPORT=http`. In this mode, `CENTREON_HOST`, `CENTREON_USERNAME`, `CENTREON_PASSWORD`, and `CENTREON_TOKEN` are not required at startup; they are provided per request via HTTP headers.
+Enable it with `AUTH_MODE=gateway` alongside `MCP_TRANSPORT=http`. The effective Centreon host and credentials arrive per request via HTTP headers. `CENTREON_HOST` and a startup credential (`CENTREON_TOKEN`, or `CENTREON_USERNAME` + `CENTREON_PASSWORD`) are still required by `LoadConfig` but act only as placeholders. `CENTREON_HOST`'s scheme is not validated in gateway mode; each `X-Centreon-Host` is validated per request instead.
 
 | Header                  | Description                                         |
 |-------------------------|-----------------------------------------------------|

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -10,6 +11,14 @@ import (
 // defaultHTTPPort is the listen port used when MCP_HTTP_PORT is unset.
 const defaultHTTPPort = 8080
 
+// URL schemes accepted for a Centreon host. These name a URL scheme and are
+// deliberately separate from the transport* constants (which name the MCP
+// transport mode), even though "http" is the same string in both.
+const (
+	schemeHTTPS = "https"
+	schemeHTTP  = "http"
+)
+
 // Config holds the server configuration.
 type Config struct {
 	Host            string
@@ -17,6 +26,7 @@ type Config struct {
 	Password        string
 	Token           string
 	AllowSelfSigned bool
+	AllowHTTP       bool
 	Transport       string
 	HTTPPort        int
 	HTTPHost        string
@@ -51,12 +61,12 @@ func LoadConfig() (Config, error) {
 		}
 	}
 
-	cfg.Transport = envOr("MCP_TRANSPORT", "stdio")
+	cfg.Transport = envOr("MCP_TRANSPORT", transportStdio)
 	cfg.LogLevel = envOr("LOG_LEVEL", "info")
-	cfg.AuthMode = envOr("AUTH_MODE", "env")
+	cfg.AuthMode = envOr("AUTH_MODE", authModeEnv)
 
 	switch cfg.Transport {
-	case "stdio", transportHTTP:
+	case transportStdio, transportHTTP:
 	default:
 		return Config{}, fmt.Errorf("invalid MCP_TRANSPORT value %q: expected stdio/http", cfg.Transport)
 	}
@@ -77,16 +87,26 @@ func LoadConfig() (Config, error) {
 	}
 	cfg.HTTPPort = port
 
-	selfSigned := os.Getenv("CENTREON_ALLOW_SELF_SIGNED")
-	if selfSigned != "" {
-		v, err := strconv.ParseBool(selfSigned)
-		if err != nil {
-			return Config{}, fmt.Errorf("invalid CENTREON_ALLOW_SELF_SIGNED value %q: expected true/false", selfSigned)
-		}
-		cfg.AllowSelfSigned = v
+	cfg.AllowSelfSigned, err = parseBoolEnv("CENTREON_ALLOW_SELF_SIGNED")
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.AllowHTTP, err = parseBoolEnv("CENTREON_ALLOW_HTTP")
+	if err != nil {
+		return Config{}, err
 	}
 
-	allowedHosts, err := loadAllowedHosts()
+	// Reject a cleartext http:// CENTREON_HOST (CWE-319) unless the operator opts
+	// in. In HTTP gateway mode CENTREON_HOST is an unused placeholder and the real
+	// hosts arrive per request via X-Centreon-Host, so its scheme is not validated
+	// here (gatewayServer validates each header value instead).
+	if !gatewayOnlyHost(&cfg) {
+		if err := validateHostScheme(cfg.Host, cfg.AllowHTTP); err != nil {
+			return Config{}, fmt.Errorf("CENTREON_HOST: %w", err)
+		}
+	}
+
+	allowedHosts, err := loadAllowedHosts(cfg.AllowHTTP)
 	if err != nil {
 		return Config{}, err
 	}
@@ -116,7 +136,7 @@ func loadHTTPPort() (int, error) {
 // os.Getenv, which cannot distinguish the two. A variable set to a non-empty
 // value that has no valid entries after trimming (e.g. " , , ") is a
 // misconfiguration and returns an error.
-func loadAllowedHosts() ([]string, error) {
+func loadAllowedHosts(allowHTTP bool) ([]string, error) {
 	raw := os.Getenv("CENTREON_ALLOWED_HOSTS")
 	if raw == "" {
 		return nil, nil
@@ -124,6 +144,11 @@ func loadAllowedHosts() ([]string, error) {
 	hosts := parseAllowedHosts(raw)
 	if len(hosts) == 0 {
 		return nil, fmt.Errorf("CENTREON_ALLOWED_HOSTS is set but contains no valid host entries")
+	}
+	for _, h := range hosts {
+		if err := validateHostScheme(h, allowHTTP); err != nil {
+			return nil, fmt.Errorf("CENTREON_ALLOWED_HOSTS: %w", err)
+		}
 	}
 	return hosts, nil
 }
@@ -146,4 +171,70 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// parseBoolEnv reads a boolean environment variable. An unset or empty value
+// yields false with no error; any other value is parsed with strconv.ParseBool.
+func parseBoolEnv(name string) (bool, error) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return false, nil
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, fmt.Errorf("invalid %s value %q: expected true/false", name, raw)
+	}
+	return v, nil
+}
+
+// gatewayOnlyHost reports whether CENTREON_HOST is a required-but-unused
+// placeholder for this configuration. In HTTP gateway mode the effective
+// Centreon hosts come from the per-request X-Centreon-Host header, so
+// CENTREON_HOST is never used to reach Centreon. Every other mode (stdio, or
+// HTTP with env auth) uses CENTREON_HOST directly, so the check requires both
+// the http transport and gateway auth mode.
+func gatewayOnlyHost(cfg *Config) bool {
+	return cfg.Transport == transportHTTP && cfg.AuthMode == authModeGateway
+}
+
+// validateHostScheme rejects a Centreon host URL whose scheme would send
+// credentials in cleartext. Credentials (username/password, or the X-AUTH-TOKEN
+// header once authenticated) ride every request to the host, so an http:// target
+// exposes them on the wire (CWE-319). https is always accepted; http only when the
+// operator opts in via CENTREON_ALLOW_HTTP. A missing or non-http(s) scheme, or an
+// unparseable URL, is rejected outright (fail closed). url.Parse normalises the
+// scheme to lowercase, so the cases below are matched in lowercase.
+func validateHostScheme(host string, allowHTTP bool) error {
+	u, err := url.Parse(host)
+	if err != nil {
+		return fmt.Errorf("invalid host url %q: %w", safeHost(host), err)
+	}
+	switch u.Scheme {
+	case schemeHTTPS:
+		return nil
+	case schemeHTTP:
+		if allowHTTP {
+			return nil
+		}
+		return fmt.Errorf("host %q uses http, which sends credentials in cleartext (CWE-319): use https or set CENTREON_ALLOW_HTTP=true", safeHost(host))
+	case "":
+		return fmt.Errorf("host %q must include a scheme (https://...)", safeHost(host))
+	default:
+		return fmt.Errorf("host %q has unsupported scheme %q: use https (or http with CENTREON_ALLOW_HTTP=true)", safeHost(host), u.Scheme)
+	}
+}
+
+// safeHost masks the password in a standard scheme://user:pass@host URL so it can
+// be put into an error message or log field without leaking an embedded credential
+// (CWE-532). It uses url.Redacted, so it covers the realistic case where a
+// credential is written into the host URL; a scheme-less or unparseable host is
+// returned unchanged, which validateHostScheme rejects anyway. This handles the
+// surfaces this file adds; the pre-existing gateway host log lines are tracked in
+// a separate issue.
+func safeHost(host string) string {
+	u, err := url.Parse(host)
+	if err != nil {
+		return host
+	}
+	return u.Redacted()
 }

--- a/config_test.go
+++ b/config_test.go
@@ -61,6 +61,7 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	t.Setenv("CENTREON_PASSWORD", "secret")
 	t.Setenv("CENTREON_TOKEN", "")
 	t.Setenv("CENTREON_ALLOW_SELF_SIGNED", "")
+	t.Setenv("CENTREON_ALLOW_HTTP", "")
 	t.Setenv("MCP_TRANSPORT", "")
 	t.Setenv("MCP_HTTP_PORT", "")
 	t.Setenv("MCP_HTTP_HOST", "")
@@ -89,6 +90,9 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	}
 	if cfg.AllowSelfSigned {
 		t.Error("expected default AllowSelfSigned false")
+	}
+	if cfg.AllowHTTP {
+		t.Error("expected default AllowHTTP false")
 	}
 }
 
@@ -230,6 +234,164 @@ func TestLoadConfig_HTTPPort(t *testing.T) {
 			}
 			if cfg.HTTPPort != tt.want {
 				t.Errorf("HTTPPort = %d, want %d", cfg.HTTPPort, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateHostScheme pins the cleartext-credential guard (CWE-319): https is
+// always accepted, http only with the opt-in, and a missing or unsupported
+// scheme (or an unparseable URL) is rejected outright.
+func TestValidateHostScheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		host      string
+		allowHTTP bool
+		wantErr   string // substring to find; "" means expect nil
+		notWant   string // substring the error must NOT contain (credential redaction)
+	}{
+		{"https accepted", "https://centreon.example.com", false, "", ""},
+		{"https uppercase scheme accepted", "HTTPS://centreon.example.com", false, "", ""},
+		{"https ipv6 accepted", "https://[::1]:8443", false, "", ""},
+		{"https with userinfo accepted", "https://admin:sekret@centreon.example.com", false, "", ""},
+		{"http rejected by default", "http://centreon.example.com", false, "CWE-319", ""},
+		{"http uppercase rejected by default", "HTTP://centreon.example.com", false, "CWE-319", ""},
+		{"http accepted with opt-in", "http://centreon.example.com", true, "", ""},
+		{"http userinfo rejected with password redacted", "http://admin:sekret@centreon.example.com", false, "CWE-319", "sekret"},
+		{"missing scheme rejected", "centreon.example.com", false, "must include a scheme", ""},
+		{"unsupported scheme rejected", "ftp://centreon.example.com", false, "unsupported scheme", ""},
+		{"host:port without scheme rejected as unsupported", "centreon.example.com:443", false, "unsupported scheme", ""},
+		{"unparseable host rejected", "127.0.0.1:8080", false, "invalid host url", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHostScheme(tt.host, tt.allowHTTP)
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Errorf("validateHostScheme(%q, %v) = %v, want nil", tt.host, tt.allowHTTP, err)
+			case tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)):
+				t.Errorf("validateHostScheme(%q, %v) = %v, want error containing %q", tt.host, tt.allowHTTP, err, tt.wantErr)
+			}
+			if tt.notWant != "" && err != nil && strings.Contains(err.Error(), tt.notWant) {
+				t.Errorf("validateHostScheme(%q) error must not leak %q, got %v", tt.host, tt.notWant, err)
+			}
+		})
+	}
+}
+
+// TestSafeHost pins that safeHost masks a userinfo password (so it cannot reach
+// logs or error messages, CWE-532) while leaving plain and unparseable hosts
+// unchanged.
+func TestSafeHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"masks password in http userinfo", "http://admin:sekret@centreon.example.com", "http://admin:xxxxx@centreon.example.com"},
+		{"masks password in https userinfo", "https://admin:sekret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		{"leaves plain host unchanged", "https://centreon.example.com", "https://centreon.example.com"},
+		{"passes through unparseable host", "127.0.0.1:8080", "127.0.0.1:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := safeHost(tt.host); got != tt.want {
+				t.Errorf("safeHost(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadConfig_HostScheme pins that CENTREON_HOST is scheme-checked at load,
+// gated by CENTREON_ALLOW_HTTP, and skipped only in HTTP gateway mode where the
+// host is an unused placeholder. It also pins that stdio+gateway still validates,
+// so the skip requires BOTH the http transport and gateway auth mode.
+func TestLoadConfig_HostScheme(t *testing.T) {
+	tests := []struct {
+		name          string
+		host          string
+		transport     string
+		authMode      string
+		allowHTTP     string
+		wantErr       string // "" = no error
+		wantAllowHTTP bool
+	}{
+		{"https host accepted", "https://h.example.com", "", "", "", "", false},
+		{"http host rejected by default", "http://h.example.com", "", "", "", "CENTREON_HOST", false},
+		{"http host accepted with opt-in", "http://h.example.com", "", "", "true", "", true},
+		{"invalid allow-http value errors", "https://h.example.com", "", "", "banana", "CENTREON_ALLOW_HTTP", false},
+		{"gateway mode skips http host check", "http://placeholder.example.com", "http", "gateway", "", "", false},
+		{"http transport env auth still validates http host", "http://h.example.com", "http", "env", "", "CENTREON_HOST", false},
+		{"stdio with gateway auth still validates http host", "http://h.example.com", "stdio", "gateway", "", "CENTREON_HOST", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CENTREON_HOST", tt.host)
+			t.Setenv("CENTREON_TOKEN", "tok")
+			t.Setenv("CENTREON_USERNAME", "")
+			t.Setenv("CENTREON_PASSWORD", "")
+			t.Setenv("CENTREON_ALLOWED_HOSTS", "")
+			t.Setenv("MCP_HTTP_PORT", "")
+			t.Setenv("MCP_TRANSPORT", tt.transport)
+			t.Setenv("AUTH_MODE", tt.authMode)
+			t.Setenv("CENTREON_ALLOW_HTTP", tt.allowHTTP)
+
+			cfg, err := LoadConfig()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("LoadConfig() error = %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadConfig() unexpected error: %v", err)
+			}
+			if cfg.AllowHTTP != tt.wantAllowHTTP {
+				t.Errorf("AllowHTTP = %v, want %v", cfg.AllowHTTP, tt.wantAllowHTTP)
+			}
+		})
+	}
+}
+
+// TestLoadConfig_AllowedHostsScheme pins that each CENTREON_ALLOWED_HOSTS entry
+// is scheme-checked at load, gated by CENTREON_ALLOW_HTTP.
+func TestLoadConfig_AllowedHostsScheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		allowHTTP string
+		wantErr   string // "" = no error
+	}{
+		{"all https accepted", "https://a.example.com,https://b.example.com", "", ""},
+		{"http entry rejected by default", "https://a.example.com,http://b.example.com", "", "CENTREON_ALLOWED_HOSTS"},
+		{"http entry accepted with opt-in", "https://a.example.com,http://b.example.com", "true", ""},
+		{"scheme-less entry rejected", "a.example.com", "", "CENTREON_ALLOWED_HOSTS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CENTREON_HOST", "https://centreon.example.com")
+			t.Setenv("CENTREON_TOKEN", "tok")
+			t.Setenv("CENTREON_USERNAME", "")
+			t.Setenv("CENTREON_PASSWORD", "")
+			t.Setenv("MCP_TRANSPORT", "")
+			t.Setenv("AUTH_MODE", "")
+			t.Setenv("MCP_HTTP_PORT", "")
+			t.Setenv("CENTREON_ALLOW_HTTP", tt.allowHTTP)
+			t.Setenv("CENTREON_ALLOWED_HOSTS", tt.value)
+
+			_, err := LoadConfig()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("LoadConfig() error = %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadConfig() unexpected error: %v", err)
 			}
 		})
 	}

--- a/server.go
+++ b/server.go
@@ -320,6 +320,11 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		return nil
 	}
 
+	if err := validateHostScheme(host, cfg.AllowHTTP); err != nil {
+		logger.Error("gateway: host scheme rejected", "host", safeHost(host), "error", err)
+		return nil
+	}
+
 	gwCfg := &Config{
 		Host:            host,
 		AllowSelfSigned: cfg.AllowSelfSigned,

--- a/server_test.go
+++ b/server_test.go
@@ -79,6 +79,20 @@ func TestGatewayServer_HostAllowlist(t *testing.T) {
 			t.Error("expected non-nil server when allowlist is empty, got nil")
 		}
 	})
+
+	t.Run("http host rejected when AllowHTTP is false", func(t *testing.T) {
+		cfg := &Config{}
+		if srv := gatewayServer(newReq("http://plain.example.com"), cfg, cache, logger, nil); srv != nil {
+			t.Error("expected nil server for cleartext http host without CENTREON_ALLOW_HTTP, got non-nil")
+		}
+	})
+
+	t.Run("http host accepted when AllowHTTP is true", func(t *testing.T) {
+		cfg := &Config{AllowHTTP: true}
+		if srv := gatewayServer(newReq("http://plain.example.com"), cfg, cache, logger, nil); srv == nil {
+			t.Error("expected non-nil server for http host with CENTREON_ALLOW_HTTP, got nil")
+		}
+	})
 }
 
 // TestLogoutCachedToken_SendsTokenToLogoutEndpoint pins that logoutCachedToken
@@ -212,6 +226,7 @@ func TestRunHTTP_GatewayLogsOutCachedSessionsOnShutdown(t *testing.T) {
 		AuthMode:  authModeGateway,
 		HTTPHost:  "127.0.0.1",
 		HTTPPort:  port,
+		AllowHTTP: true, // fake Centreon (httptest) is http loopback
 	}
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -393,7 +408,7 @@ func TestGatewayServer_TokenCachePinsPassword(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	cfg := &Config{} // no allowlist restriction
+	cfg := &Config{AllowHTTP: true} // no allowlist restriction; httptest server is http loopback
 	cache := NewTokenCache(time.Minute)
 
 	req := func(pass string) *http.Request {


### PR DESCRIPTION
## Summary

Gateway mode and env/stdio auth pass Centreon credentials (username and password, or the `X-AUTH-TOKEN` session header) to whatever host is configured. If that host uses `http://`, the credentials travel in cleartext (CWE-319), and nothing validated the scheme: `CENTREON_HOST`, every `CENTREON_ALLOWED_HOSTS` entry, and the gateway `X-Centreon-Host` header could all be plain http. This is the transport-security half of the concern raised on #27, which restricted which host is reachable, not whether the connection is encrypted.

This adds `validateHostScheme` and enforces it uniformly across every credential-bearing host input: `https://` is always accepted, `http://` only when the operator opts in with `CENTREON_ALLOW_HTTP=true`, and a missing or unsupported scheme is rejected. It runs on `CENTREON_HOST` at load (skipped in HTTP gateway mode, where the host is a required-but-unused placeholder and the real hosts arrive per request), on each `CENTREON_ALLOWED_HOSTS` entry at load, and on `X-Centreon-Host` per request. When the allowlist is empty the per-request check is the only defense, so it runs unconditionally.

Rejection errors and the gateway rejection log run the host through a `safeHost` helper (`url.Redacted`) first, so a credential embedded in a host URL (`https://user:pass@host`) is not echoed into logs (CWE-532).

## Breaking change

Rejecting `http://` by default is backward-incompatible: an existing plain-http or LAN deployment must set `CENTREON_ALLOW_HTTP=true` after upgrading, and `CENTREON_ALLOWED_HOSTS` entries must include a scheme. The failure is loud and actionable (the error names CWE-319 and the opt-in variable), and the README documents the upgrade path. There is no CHANGELOG in the repo, so this warrants a minor or major version bump and a release note at your discretion.

## Related issues

Closes #28. Relates to #36 (cross-host redirect guard) and #41 (redact userinfo in the pre-existing gateway host log lines, filed during review).

## Test plan

- [x] `go test ./...` and `go test -race ./...` pass; `golangci-lint run ./...` reports 0 issues
- [x] Unit tests for `validateHostScheme` (https, http with and without opt-in, missing/unsupported scheme, IPv6, unparseable, uppercase, userinfo redaction) and `safeHost`
- [x] `LoadConfig` scheme enforcement including the gateway-mode skip and the full Transport x AuthMode cross-product (http+env and stdio+gateway both still validate)
- [x] `CENTREON_ALLOWED_HOSTS` entry scheme enforcement
- [x] Gateway `X-Centreon-Host` per-request rejection/acceptance by `CENTREON_ALLOW_HTTP`
- [x] Every new test verified by deleting the production line it pins and confirming it goes red