### PR TITLE
fix: bound the stdio-mode shutdown logout with a timeout (#38)

### DIFF
--- a/server.go
+++ b/server.go
@@ -173,15 +173,36 @@ func runStdio(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient 
 		if err := client.Login(ctx); err != nil {
 			return fmt.Errorf("centreon login: %w", err)
 		}
-		defer func() {
-			_ = client.Logout(context.WithoutCancel(ctx))
-		}()
+		defer logoutClientBounded(ctx, client, logger)
 		logger.Info("centreon client authenticated", "host", cfg.Host)
 	}
 
 	s := buildServer(client, logger)
 	logger.Info("centreon-mcp-go ready", "transport", "stdio")
 	return s.Run(ctx, &mcp.StdioTransport{})
+}
+
+// logoutClientBounded logs client out during shutdown on a fresh, cancel-immune,
+// time-bounded context. It is the stdio counterpart to gracefulShutdown's
+// shared-client logout: the ctx passed to runStdio is cancelled on shutdown, so the
+// logout runs on context.WithoutCancel to survive that cancellation, but it must
+// still be bounded by shutdownLogoutTimeout so an unreachable or hung Centreon
+// cannot block process exit (issue #38).
+//
+// It debug-logs and swallows its own logout error so best-effort cleanup never
+// fails the process, and logs success at info to match gracefulShutdown's
+// shared-client path and pair with runStdio's login-success line. It reuses the
+// logger-bearing client from runStdio (like gracefulShutdown's shared client,
+// unlike logoutCachedToken's nil-logger client), so a failing shutdown logout can
+// still surface a line from the centreon client's own request logging.
+func logoutClientBounded(ctx context.Context, client *centreon.Client, logger *slog.Logger) {
+	logoutCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownLogoutTimeout)
+	defer cancel()
+	if err := client.Logout(logoutCtx); err != nil {
+		logger.Debug("centreon client logout failed", "error", err)
+	} else {
+		logger.Info("centreon client logged out")
+	}
 }
 
 // runHTTP starts the MCP server over HTTP.

--- a/server_test.go
+++ b/server_test.go
@@ -125,6 +125,64 @@ func TestLogoutCachedToken_SendsTokenToLogoutEndpoint(t *testing.T) {
 	}
 }
 
+// roundTripFunc adapts a function to http.RoundTripper so a test can observe the
+// request an http.Client is about to send.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestLogoutClientBounded_BoundsLogoutWithDeadline pins issue #38: the stdio
+// shutdown logout must run on a bounded, cancel-immune context. Graceful shutdown
+// cancels the parent ctx, so the logout runs on context.WithoutCancel to survive
+// that cancellation, but it must still carry a deadline (shutdownLogoutTimeout) so
+// an unreachable Centreon cannot block process exit. The test drives a client
+// whose transport records whether the logout request carried a deadline and
+// asserts one is present even though the parent ctx is already cancelled. The
+// http.Client sets no Timeout of its own, so the only possible source of a request
+// deadline is the bounded logout context under test.
+func TestLogoutClientBounded_BoundsLogoutWithDeadline(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var logoutCount atomic.Int32
+	var hadDeadline atomic.Bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/logout", func(w http.ResponseWriter, _ *http.Request) {
+		logoutCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if _, ok := r.Context().Deadline(); ok {
+				hadDeadline.Store(true)
+			}
+			return http.DefaultTransport.RoundTrip(r)
+		}),
+	}
+
+	client, err := newCentreonClient(srv.URL, &Config{Token: "tok-xyz"}, logger, httpClient)
+	if err != nil {
+		t.Fatalf("newCentreonClient: %v", err)
+	}
+
+	// Simulate graceful shutdown: the parent context is already cancelled when the
+	// deferred logout fires.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	logoutClientBounded(ctx, client, logger)
+
+	if n := logoutCount.Load(); n != 1 {
+		t.Fatalf("bounded logout must still call GET /logout once despite a cancelled parent ctx, got %d", n)
+	}
+	if !hadDeadline.Load() {
+		t.Error("stdio shutdown logout must bound the logout with a deadline (issue #38); the request carried none")
+	}
+}
+
 // TestDrainAndLogout_LogsOutEveryCachedTokenAndEmptiesCache pins the #5 shutdown
 // behaviour end to end: every token in the cache is logged out on the Centreon
 // server and the cache is left empty.


### PR DESCRIPTION
## Summary

In stdio transport mode, `runStdio` deferred `client.Logout(context.WithoutCancel(ctx))` with no deadline of its own. A hung or unreachable Centreon at shutdown could therefore stall the deferred logout, bounded only by the shared HTTP client's 30s timeout. The HTTP path already bounds its shutdown logouts with `shutdownLogoutTimeout` (added in #35); this change gives the stdio path the same 10s budget so process exit stays prompt.

The logout logic is extracted into `logoutClientBounded`, which wraps `client.Logout` in `context.WithTimeout(context.WithoutCancel(ctx), shutdownLogoutTimeout)`. `WithoutCancel` lets the logout survive the shutdown-cancelled parent context, while `WithTimeout` re-imposes the bound, mirroring `gracefulShutdown`'s shared-client logout exactly. It debug-logs and swallows its own logout error (best-effort cleanup must never fail the process) and logs success at info to match that HTTP sibling and pair with `runStdio`'s existing login-success line.

Note on logging: because `logoutClientBounded` reuses the logger-bearing client `runStdio` serves on (like `gracefulShutdown`'s shared client, unlike `logoutCachedToken`'s deliberately nil-logger client), a logout that times out here will still surface one request-failed line from the centreon client's own request logging. That is expected on a hung shutdown and is documented in the helper's doc comment.

## Related Issues

Fixes #38

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` (83.3% coverage) all green
- [x] `golangci-lint run ./...` reports 0 issues
- [x] New `TestLogoutClientBounded_BoundsLogoutWithDeadline` drives the helper with an already-cancelled parent ctx through a zero-Timeout HTTP client whose transport records whether the logout request carried a context deadline. It asserts the logout still fires exactly once and that the request is deadline-bounded. Verified it fails (deadline absent) when the `WithTimeout` wrap is removed, so it genuinely pins the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout reliability during shutdown by allowing logout requests to complete within a defined time limit.
  * Logout errors during shutdown are safely handled without interrupting the shutdown process.
  * Added clearer diagnostic logging for successful and unsuccessful logout attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->