### PR TITLE
feat: warn when CENTREON_ALLOWED_HOSTS is set outside gateway mode (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ On graceful shutdown (SIGINT/SIGTERM) the server logs out the Centreon sessions 
 
 ### Host allowlist
 
-By default gateway mode connects to whatever `X-Centreon-Host` a caller supplies, so an exposed endpoint can be used as an SSRF or open-proxy primitive. Set `CENTREON_ALLOWED_HOSTS` to a comma-separated list of permitted host URLs to restrict this; requests whose `X-Centreon-Host` does not match an entry exactly are rejected. When the variable is unset or empty, behavior is unchanged (any host is accepted) and the server logs a warning at startup. Matching is exact and case-sensitive, so list each host URL as callers send it.
+By default gateway mode connects to whatever `X-Centreon-Host` a caller supplies, so an exposed endpoint can be used as an SSRF or open-proxy primitive. Set `CENTREON_ALLOWED_HOSTS` to a comma-separated list of permitted host URLs to restrict this; requests whose `X-Centreon-Host` does not match an entry exactly are rejected. When the variable is unset or empty, behavior is unchanged (any host is accepted) and the server logs a warning at startup. Matching is exact and case-sensitive, so list each host URL as callers send it. The allowlist is enforced only in gateway mode; under any other mode (stdio, or `http` with `env` auth) a configured `CENTREON_ALLOWED_HOSTS` restricts nothing, and the server logs a startup warning so the ineffective setting is visible.
 
 ```bash
 export CENTREON_ALLOWED_HOSTS="https://centreon.example.com,https://centreon2.example.com"

--- a/config.go
+++ b/config.go
@@ -100,7 +100,7 @@ func LoadConfig() (Config, error) {
 	// in. In HTTP gateway mode CENTREON_HOST is an unused placeholder and the real
 	// hosts arrive per request via X-Centreon-Host, so its scheme is not validated
 	// here (gatewayServer validates each header value instead).
-	if !gatewayOnlyHost(&cfg) {
+	if !gatewayMode(&cfg) {
 		if err := validateHostScheme(cfg.Host, cfg.AllowHTTP); err != nil {
 			return Config{}, fmt.Errorf("CENTREON_HOST: %w", err)
 		}
@@ -187,13 +187,13 @@ func parseBoolEnv(name string) (bool, error) {
 	return v, nil
 }
 
-// gatewayOnlyHost reports whether CENTREON_HOST is a required-but-unused
-// placeholder for this configuration. In HTTP gateway mode the effective
-// Centreon hosts come from the per-request X-Centreon-Host header, so
-// CENTREON_HOST is never used to reach Centreon. Every other mode (stdio, or
-// HTTP with env auth) uses CENTREON_HOST directly, so the check requires both
-// the http transport and gateway auth mode.
-func gatewayOnlyHost(cfg *Config) bool {
+// gatewayMode reports whether the server runs in HTTP gateway mode: http
+// transport with gateway auth. This is the only mode where the effective
+// Centreon hosts arrive per request via the X-Centreon-Host header (so
+// CENTREON_HOST is an unused placeholder) and the only mode that enforces the
+// CENTREON_ALLOWED_HOSTS allowlist. Every other mode (stdio, or HTTP with env
+// auth) uses CENTREON_HOST directly and never enforces the allowlist.
+func gatewayMode(cfg *Config) bool {
 	return cfg.Transport == transportHTTP && cfg.AuthMode == authModeGateway
 }
 

--- a/server.go
+++ b/server.go
@@ -139,9 +139,26 @@ func newCentreonClient(host string, cfg *Config, logger *slog.Logger, httpClient
 	return centreon.NewClient(host, opts...)
 }
 
+// warnIfAllowlistIneffective emits a startup warning when CENTREON_ALLOWED_HOSTS
+// is configured but the effective mode will never consult it. The allowlist is
+// only enforced in gateway mode (http transport with gateway auth); in every
+// other mode a set value is silently a no-op, so without this signal an operator
+// can believe they have restricted the reachable hosts when they have not. This
+// is a least-surprise warning, not a security control: outside gateway mode
+// there is no per-request X-Centreon-Host to restrict. It mirrors the gateway
+// allowlist status lines emitted in runHTTP.
+func warnIfAllowlistIneffective(cfg *Config, logger *slog.Logger) {
+	if len(cfg.AllowedHosts) == 0 || gatewayMode(cfg) {
+		return
+	}
+	logger.Warn("CENTREON_ALLOWED_HOSTS is set but is only enforced in gateway mode (AUTH_MODE=gateway with MCP_TRANSPORT=http); it has no effect with the current transport/auth mode",
+		"transport", cfg.Transport, "authMode", cfg.AuthMode)
+}
+
 // run starts the server with the configured transport.
 func run(ctx context.Context, cfg *Config, logger *slog.Logger) error {
 	logger.Info("centreon-mcp-go starting", "version", version, "transport", cfg.Transport)
+	warnIfAllowlistIneffective(cfg, logger)
 
 	// One HTTP client, shared across all requests. It always installs the
 	// cross-host redirect guard (X-AUTH-TOKEN must not leak, CWE-522) and, when

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -737,5 +738,51 @@ func TestRun_EnvLoginRefusesCrossHostRedirect(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "centreon login") || !strings.Contains(err.Error(), "cross-host redirect") {
 		t.Errorf("want a login error caused by the cross-host redirect guard, got: %v", err)
+	}
+}
+
+// TestWarnIfAllowlistIneffective pins issue #31: a configured
+// CENTREON_ALLOWED_HOSTS is only consulted in gateway mode (http transport with
+// gateway auth). In every other mode a set value is silently a no-op, so startup
+// must emit exactly one Warn line to signal the least-surprise gap; in the
+// enforcing mode, and whenever no allowlist is set, it must stay silent.
+func TestWarnIfAllowlistIneffective(t *testing.T) {
+	t.Parallel()
+
+	const marker = "CENTREON_ALLOWED_HOSTS is set but"
+	allowlist := []string{"https://a.example.com"}
+
+	tests := []struct {
+		name      string
+		hosts     []string
+		transport string
+		authMode  string
+		wantWarn  bool
+	}{
+		{"set, stdio+env: inert, warns", allowlist, transportStdio, authModeEnv, true},
+		{"set, http+env: inert, warns", allowlist, transportHTTP, authModeEnv, true},
+		{"set, stdio+gateway: inert, warns", allowlist, transportStdio, authModeGateway, true},
+		{"set, http+gateway: enforced, silent", allowlist, transportHTTP, authModeGateway, false},
+		{"unset, http+gateway: silent", nil, transportHTTP, authModeGateway, false},
+		{"unset, stdio+env: silent", nil, transportStdio, authModeEnv, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			cfg := &Config{AllowedHosts: tt.hosts, Transport: tt.transport, AuthMode: tt.authMode}
+
+			warnIfAllowlistIneffective(cfg, logger)
+
+			wantCount := 0
+			if tt.wantWarn {
+				wantCount = 1
+			}
+			if gotCount := strings.Count(buf.String(), marker); gotCount != wantCount {
+				t.Errorf("warn lines = %d, want %d; log=%q", gotCount, wantCount, buf.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`CENTREON_ALLOWED_HOSTS` is parsed and validated in every mode, but it is only enforced in gateway mode (`MCP_TRANSPORT=http` with `AUTH_MODE=gateway`), which is the only mode that consults the per-request `X-Centreon-Host` header. Set in any other mode, a valid allowlist is silently a no-op with no runtime signal, so an operator can believe reachable hosts are restricted when they are not.

This adds a startup `Warn` when the allowlist is configured but the effective mode will not enforce it. This is Option 1 from the issue: log-only, no behavior change. The warning fires from `run()`, so it covers every transport, and it is mutually exclusive with the existing gateway allowlist status lines in `runHTTP` (that path returns early in gateway mode). By the time `run()` executes, the allowlist is already validated, so the message is accurate: a malformed value still fails at load in every mode.

The `gatewayOnlyHost` predicate is renamed to `gatewayMode`: it is the single `http`+`gateway` predicate that both the `CENTREON_HOST` placeholder logic and the allowlist enforcement consult, and the generalized name reflects the second caller this change adds. The README host-allowlist section now documents the new warning.

## Related Issues

Closes #31

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go test ./...` passes (new `TestWarnIfAllowlistIneffective` covers the full transport x auth matrix, allowlist set and unset)
- [x] Mutation-checked: removing the `gatewayMode` guard or the empty-allowlist guard turns the matching subcase red; a duplicate warn fails the `exactly one` count assertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the host allowlist is only effective in Gateway Mode.
  * Documented that setting it elsewhere triggers a startup warning.

* **Bug Fixes**
  * Improved host validation behavior for Gateway Mode configurations.
  * Added a startup warning when the host allowlist is configured but ineffective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->