### PR TITLE
cleanup: drop write-only fields from gateway gwCfg literals (#39)

### DIFF
--- a/server.go
+++ b/server.go
@@ -123,6 +123,14 @@ func newHTTPClient(allowSelfSigned bool) (*http.Client, error) {
 // production httpClient is always the newHTTPClient product, so the cross-host
 // redirect guard and shared timeout apply to every request; it may be nil in
 // tests, in which case the dependency's default client (no redirect guard) is used.
+//
+// It reads only the auth credentials from cfg (Token, or Username/Password); the
+// host comes from the host parameter. It deliberately does not read
+// cfg.AllowSelfSigned: self-signed TLS is applied once on httpClient by
+// newHTTPClient. Building a fresh per-client transport from that flag here would
+// drop httpClient's cross-host redirect guard and reopen the X-AUTH-TOKEN leak
+// (CWE-522, #36); if it must vary per client, clone httpClient and keep its
+// CheckRedirect.
 func newCentreonClient(host string, cfg *Config, logger *slog.Logger, httpClient *http.Client) (*centreon.Client, error) {
 	opts := []centreon.Option{}
 	if cfg.Token != "" {
@@ -337,7 +345,7 @@ func gracefulShutdown(serveCtx context.Context, httpServer *http.Server, sharedC
 		}
 	}
 	if tokenCache != nil {
-		drainAndLogout(logoutCtx, tokenCache, cfg, logger, httpClient)
+		drainAndLogout(logoutCtx, tokenCache, logger, httpClient)
 	}
 }
 
@@ -363,10 +371,7 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		return nil
 	}
 
-	gwCfg := &Config{
-		Host:            host,
-		AllowSelfSigned: cfg.AllowSelfSigned,
-	}
+	gwCfg := &Config{}
 
 	switch {
 	case token != "":
@@ -425,7 +430,7 @@ func hostAllowed(host string, allowed []string) bool {
 // tokens and logging them out cannot break a live request. Logouts run
 // concurrently, bounded by gatewayLogoutConcurrency and by ctx; once ctx is done
 // the loop stops spawning further attempts that would only fail immediately.
-func drainAndLogout(ctx context.Context, tc *TokenCache, cfg *Config, logger *slog.Logger, httpClient *http.Client) {
+func drainAndLogout(ctx context.Context, tc *TokenCache, logger *slog.Logger, httpClient *http.Client) {
 	tokens := tc.Drain()
 	if len(tokens) == 0 {
 		return
@@ -438,7 +443,7 @@ func drainAndLogout(ctx context.Context, tc *TokenCache, cfg *Config, logger *sl
 			break
 		}
 		g.Go(func() error {
-			logoutCachedToken(ctx, ct.Host, ct.Token, cfg, logger, httpClient)
+			logoutCachedToken(ctx, ct.Host, ct.Token, logger, httpClient)
 			return nil
 		})
 	}
@@ -454,11 +459,11 @@ func drainAndLogout(ctx context.Context, tc *TokenCache, cfg *Config, logger *sl
 // client logs every failed request at Error, so on a cancelled or failing
 // shutdown logout it would emit dependency-layer Error noise that contradicts
 // this function's own debug-and-swallow handling.
-func logoutCachedToken(ctx context.Context, host, token string, cfg *Config, logger *slog.Logger, httpClient *http.Client) {
+func logoutCachedToken(ctx context.Context, host, token string, logger *slog.Logger, httpClient *http.Client) {
 	if token == "" {
 		return
 	}
-	gwCfg := &Config{Host: host, Token: token, AllowSelfSigned: cfg.AllowSelfSigned}
+	gwCfg := &Config{Token: token}
 	client, err := newCentreonClient(host, gwCfg, nil, httpClient)
 	if err != nil {
 		logger.Debug("gateway: failed to build client for token logout", "host", host, "error", err)

--- a/server_test.go
+++ b/server_test.go
@@ -116,7 +116,7 @@ func TestLogoutCachedToken_SendsTokenToLogoutEndpoint(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	logoutCachedToken(t.Context(), srv.URL, "tok-xyz", &Config{}, logger, nil)
+	logoutCachedToken(t.Context(), srv.URL, "tok-xyz", logger, nil)
 
 	if n := logoutCount.Load(); n != 1 {
 		t.Fatalf("expected exactly 1 logout call, got %d", n)
@@ -207,7 +207,7 @@ func TestDrainAndLogout_LogsOutEveryCachedTokenAndEmptiesCache(t *testing.T) {
 	cache.Set(srv.URL, "admin", "p2", "tok-2")
 	cache.Set(srv.URL, "admin", "p3", "tok-3")
 
-	drainAndLogout(t.Context(), cache, &Config{}, logger, nil)
+	drainAndLogout(t.Context(), cache, logger, nil)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -242,7 +242,7 @@ func TestDrainAndLogout_SwallowsLogoutFailuresAndEmptiesCache(t *testing.T) {
 	cache.Set(srv.URL, "admin", "p2", "tok-2")
 	cache.Set(srv.URL, "admin", "p3", "tok-3")
 
-	drainAndLogout(t.Context(), cache, &Config{}, logger, nil)
+	drainAndLogout(t.Context(), cache, logger, nil)
 
 	if got := attempts.Load(); got != 3 {
 		t.Errorf("every cached session should be attempted despite failures: got %d, want 3", got)
@@ -738,6 +738,44 @@ func TestRun_EnvLoginRefusesCrossHostRedirect(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "centreon login") || !strings.Contains(err.Error(), "cross-host redirect") {
 		t.Errorf("want a login error caused by the cross-host redirect guard, got: %v", err)
+	}
+}
+
+// TestNewCentreonClient_AllowSelfSignedDoesNotBypassRedirectGuard pins issue #39:
+// newCentreonClient must route every request through the shared, redirect-guarded
+// httpClient it is given and must NOT read cfg.AllowSelfSigned. Self-signed TLS is
+// applied once on that shared client by newHTTPClient; wiring cfg.AllowSelfSigned
+// into a per-client transport here would build a second client that bypasses the
+// cross-host redirect guard and reopen the X-AUTH-TOKEN leak (CWE-522, #36). So
+// even with AllowSelfSigned set, a cross-host login redirect must still be refused.
+func TestNewCentreonClient_AllowSelfSignedDoesNotBypassRedirectGuard(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /centreon/api/latest/login", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://other.invalid/steal", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	httpClient, err := newHTTPClient(false)
+	if err != nil {
+		t.Fatalf("newHTTPClient: %v", err)
+	}
+
+	// AllowSelfSigned is deliberately set: newCentreonClient must ignore it and use
+	// the guarded httpClient, so the cross-host redirect is still refused.
+	client, err := newCentreonClient(srv.URL, &Config{Username: "admin", Password: "secret", AllowSelfSigned: true}, nil, httpClient)
+	if err != nil {
+		t.Fatalf("newCentreonClient: %v", err)
+	}
+
+	err = client.Login(t.Context())
+	if err == nil {
+		t.Fatal("login must refuse the cross-host redirect via the shared guarded client, got nil")
+	}
+	if !strings.Contains(err.Error(), "cross-host redirect") {
+		t.Errorf("want a cross-host redirect error (shared guard in effect despite AllowSelfSigned), got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`newCentreonClient` takes the host as a separate parameter and reads only the auth credentials (`Token`, or `Username`/`Password`) from its `Config`. It never reads `Config.AllowSelfSigned` or `Config.Host`. Yet the per-request `gwCfg` literals in `gatewayServer` and `logoutCachedToken` set both fields, which is write-only dead code.

Self-signed TLS and the cross-host redirect guard (CWE-522, #36) come entirely from the single shared `*http.Client` that `run()` builds once via `newHTTPClient` and threads to every gateway path. The dead `AllowSelfSigned` copies were a latent footgun: a future reader could wire `gwCfg.AllowSelfSigned` into `newCentreonClient`, build a second unguarded client, and reopen the X-AUTH-TOKEN cross-host redirect leak that #36 closed.

This drops `AllowSelfSigned` and `Host` from both `gwCfg` literals. Removing `AllowSelfSigned` left `cfg` unused in `logoutCachedToken` and `drainAndLogout` (golangci-lint's `unparam` is enabled), so the now-dead `cfg *Config` parameter is dropped from both and their call sites updated; `gracefulShutdown` keeps `cfg` because it still reads `cfg.Token`. `newCentreonClient` now documents that it deliberately ignores `AllowSelfSigned` and why re-wiring it is dangerous.

## Related Issues

Closes #39

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `golangci-lint run ./...` reports 0 issues (unparam satisfied after the param removal)
- [x] `go test -race ./...` passes
- [x] New `TestNewCentreonClient_AllowSelfSignedDoesNotBypassRedirectGuard`: with `AllowSelfSigned` set, a cross-host login redirect is still refused. Sabotage-verified: reintroducing the footgun (`if cfg.AllowSelfSigned { httpClient = &http.Client{} }`) turns it red