### PR TITLE
fix: redact userinfo in gateway host log lines, harden safeHost (#41)

### DIFF
--- a/config.go
+++ b/config.go
@@ -224,17 +224,61 @@ func validateHostScheme(host string, allowHTTP bool) error {
 	}
 }
 
-// safeHost masks the password in a standard scheme://user:pass@host URL so it can
-// be put into an error message or log field without leaking an embedded credential
-// (CWE-532). It uses url.Redacted, so it covers the realistic case where a
-// credential is written into the host URL; a scheme-less or unparseable host is
-// returned unchanged, which validateHostScheme rejects anyway. This handles the
-// surfaces this file adds; the pre-existing gateway host log lines are tracked in
-// a separate issue.
+// safeHost masks the password in a host URL so it can be put into a log field or
+// error message without leaking an embedded credential (CWE-532). It redacts the
+// standard scheme://user:pass@host form via url.Redacted and the scheme-less
+// user:pass@host form (which url.Parse treats as scheme:opaque, exposing no userinfo
+// to mask) by reparsing it as an authority. A password carrying an unescaped '/',
+// '?' or '#' breaks url.Parse; that form falls back to masking the password span
+// textually, so redaction fails closed. A credential-free host is returned
+// unchanged, so log greps on the hostname still match. Every host-URL log field and
+// validateHostScheme error message routes through it.
+//
+// Limitation: a password containing an unencoded "//" or "://" is indistinguishable
+// from URL scheme/authority structure (url.Parse reads it as a scheme and username),
+// so it may not be fully masked. RFC 3986 requires percent-encoding such characters
+// in userinfo; the realistic single-'/' base64 case is handled.
 func safeHost(host string) string {
-	u, err := url.Parse(host)
-	if err != nil {
-		return host
+	if u, err := url.Parse(host); err == nil {
+		if u.User != nil {
+			return u.Redacted()
+		}
+		// A well-formed hierarchical URL with a real host and no userinfo carries no
+		// credential: any ':' or '@' is in the host:port, path or query. A userinfo
+		// password that begins with '/' defeats that, because url.Parse mis-splits it
+		// into the path, leaving the host empty (scheme-less input) or ending in a
+		// bare ':' (scheme-present input); both fall through to be masked.
+		if u.Opaque == "" && u.Host != "" && !strings.HasSuffix(u.Host, ":") {
+			return host
+		}
 	}
-	return u.Redacted()
+	if u, err := url.Parse("//" + host); err == nil && u.User != nil {
+		return strings.TrimPrefix(u.Redacted(), "//")
+	}
+	return maskAuthorityPassword(host)
+}
+
+// maskAuthorityPassword fails closed for host strings url.Parse cannot decode into
+// userinfo (a password with an unescaped '/', '?' or '#', a leading "://", or an
+// invalid percent-escape). It masks the password span from the first ':' to the
+// last '@' (the userinfo/host delimiter). A ':' sitting behind a path separator is
+// left alone, and a host with no userinfo is returned unchanged, so a legitimate
+// ':' or '@' in a path or query is never touched.
+func maskAuthorityPassword(host string) string {
+	rest, prefix := host, ""
+	// A leading "scheme://" or "//" precedes the authority; only treat "//" as the
+	// authority marker when nothing path-like or an '@' comes before it.
+	if i := strings.Index(rest, "//"); i >= 0 && !strings.ContainsAny(rest[:i], "/?#@") {
+		prefix, rest = rest[:i+2], rest[i+2:]
+	}
+	at := strings.LastIndexByte(rest, '@')
+	if at < 0 {
+		return host // no userinfo
+	}
+	userinfo := rest[:at]
+	colon := strings.IndexByte(userinfo, ':')
+	if colon < 0 || strings.ContainsAny(userinfo[:colon], "/?#") {
+		return host // no password, or the ':' is in a path/query rather than userinfo
+	}
+	return prefix + userinfo[:colon] + ":xxxxx" + rest[at:]
 }

--- a/config_test.go
+++ b/config_test.go
@@ -281,8 +281,9 @@ func TestValidateHostScheme(t *testing.T) {
 }
 
 // TestSafeHost pins that safeHost masks a userinfo password (so it cannot reach
-// logs or error messages, CWE-532) while leaving plain and unparseable hosts
-// unchanged.
+// logs or error messages, CWE-532) across every form that can carry one, including
+// the scheme-less user:pass@host form url.Redacted alone does not mask (issue #41),
+// while leaving a credential-free host byte for byte unchanged.
 func TestSafeHost(t *testing.T) {
 	tests := []struct {
 		name string
@@ -291,7 +292,36 @@ func TestSafeHost(t *testing.T) {
 	}{
 		{"masks password in http userinfo", "http://admin:sekret@centreon.example.com", "http://admin:xxxxx@centreon.example.com"},
 		{"masks password in https userinfo", "https://admin:sekret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		// Scheme-less/opaque forms: url.Parse leaves no userinfo for url.Redacted, so
+		// these leaked before #41. safeHost reparses (or masks textually) instead.
+		{"masks scheme-less userinfo", "admin:sekret@centreon.example.com", "admin:xxxxx@centreon.example.com"},
+		{"masks scheme-less userinfo with path", "admin:sekret@centreon.example.com/mon", "admin:xxxxx@centreon.example.com/mon"},
+		{"masks leading //authority userinfo", "//admin:sekret@centreon.example.com", "//admin:xxxxx@centreon.example.com"},
+		{"masks empty-scheme ://authority userinfo", "://admin:sekret@centreon.example.com", "://admin:xxxxx@centreon.example.com"},
+		{"masks userinfo with port and path", "https://admin:sekret@centreon.example.com:8443/mon?q=1", "https://admin:xxxxx@centreon.example.com:8443/mon?q=1"},
+		{"masks userinfo when the path also has @", "https://admin:sekret@centreon.example.com/p@th", "https://admin:xxxxx@centreon.example.com/p@th"},
+		// url.Parse fails outright on the bad percent-escape, so the textual fallback
+		// must still redact rather than return the raw credential.
+		{"masks userinfo in an unparseable URL", "https://admin:sekret@centreon.example.com/%zz", "https://admin:xxxxx@centreon.example.com/%zz"},
+		// A password containing an unescaped '/', '?' or '#' breaks url.Parse and must
+		// not fail open (base64 passwords routinely contain '/').
+		{"masks password with a slash", "https://admin:aB9/xY2z@centreon.example.com/api", "https://admin:xxxxx@centreon.example.com/api"},
+		{"masks scheme-less password with a slash", "admin:aB9/xY2z@centreon.example.com", "admin:xxxxx@centreon.example.com"},
+		{"masks password with a question mark", "https://admin:pa?ss@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		{"masks password with a hash", "https://admin:pa#ss@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		{"masks password beginning with a slash", "https://admin:/sekret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		{"masks scheme-less password beginning with a slash", "admin:/sekret@centreon.example.com", "admin:xxxxx@centreon.example.com"},
+		{"masks scheme-less password beginning with a question mark", "admin:?sekret@centreon.example.com", "admin:xxxxx@centreon.example.com"},
+		// Credential-free hosts whose path or query legitimately contains ':' or '@'
+		// must never be corrupted.
+		{"leaves host:port with @ in path unchanged", "https://centreon.example.com:8080/a@b", "https://centreon.example.com:8080/a@b"},
+		{"leaves : and @ in query unchanged", "https://centreon.example.com:8443/x?a=b:c@d", "https://centreon.example.com:8443/x?a=b:c@d"},
+		{"leaves IPv6 host with @ in path unchanged", "https://[2001:db8::1]/x@y", "https://[2001:db8::1]/x@y"},
+		{"leaves scheme-less host with @ in path unchanged", "centreon.example.com/a@b", "centreon.example.com/a@b"},
 		{"leaves plain host unchanged", "https://centreon.example.com", "https://centreon.example.com"},
+		{"leaves @ in query unchanged", "https://centreon.example.com/path?x=a@b.com", "https://centreon.example.com/path?x=a@b.com"},
+		{"leaves userinfo without a password unchanged", "https://user@centreon.example.com", "https://user@centreon.example.com"},
+		{"leaves empty string unchanged", "", ""},
 		{"passes through unparseable host", "127.0.0.1:8080", "127.0.0.1:8080"},
 	}
 

--- a/server.go
+++ b/server.go
@@ -199,7 +199,7 @@ func runStdio(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient 
 			return fmt.Errorf("centreon login: %w", err)
 		}
 		defer logoutClientBounded(ctx, client, logger)
-		logger.Info("centreon client authenticated", "host", cfg.Host)
+		logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
 	}
 
 	s := buildServer(client, logger)
@@ -244,7 +244,7 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 			if err := client.Login(ctx); err != nil {
 				return fmt.Errorf("centreon login: %w", err)
 			}
-			logger.Info("centreon client authenticated", "host", cfg.Host)
+			logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
 		}
 		sharedClient = client
 	} else {
@@ -362,7 +362,7 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 	}
 
 	if !hostAllowed(host, cfg.AllowedHosts) {
-		logger.Error("gateway: host not in allowlist", "host", host)
+		logger.Error("gateway: host not in allowlist", "host", safeHost(host))
 		return nil
 	}
 
@@ -378,36 +378,36 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		gwCfg.Token = token
 	case username != "" && password != "":
 		if cached, ok := tokenCache.Get(host, username, password); ok {
-			logger.Debug("gateway: using cached token", "host", host)
+			logger.Debug("gateway: using cached token", "host", safeHost(host))
 			gwCfg.Token = cached
 		} else {
 			gwCfg.Username = username
 			gwCfg.Password = password
 		}
 	default:
-		logger.Error("gateway: missing credentials", "host", host)
+		logger.Error("gateway: missing credentials", "host", safeHost(host))
 		return nil
 	}
 
 	client, err := newCentreonClient(host, gwCfg, logger, httpClient)
 	if err != nil {
-		logger.Error("gateway: failed to create client", "host", host, "error", err)
+		logger.Error("gateway: failed to create client", "host", safeHost(host), "error", err)
 		return nil
 	}
 
 	if gwCfg.Token == "" {
 		if err := client.Login(r.Context()); err != nil {
-			logger.Error("gateway: authentication failed", "host", host, "error", err)
+			logger.Error("gateway: authentication failed", "host", safeHost(host), "error", err)
 			return nil
 		}
 		// Cache the token for subsequent requests
 		if tok := client.Token(); tok != "" {
 			tokenCache.Set(host, username, password, tok)
-			logger.Debug("gateway: cached token after login", "host", host)
+			logger.Debug("gateway: cached token after login", "host", safeHost(host))
 		}
 	}
 
-	logger.Debug("gateway: created per-request client", "host", host)
+	logger.Debug("gateway: created per-request client", "host", safeHost(host))
 	return buildServer(client, logger)
 }
 
@@ -466,12 +466,12 @@ func logoutCachedToken(ctx context.Context, host, token string, logger *slog.Log
 	gwCfg := &Config{Token: token}
 	client, err := newCentreonClient(host, gwCfg, nil, httpClient)
 	if err != nil {
-		logger.Debug("gateway: failed to build client for token logout", "host", host, "error", err)
+		logger.Debug("gateway: failed to build client for token logout", "host", safeHost(host), "error", err)
 		return
 	}
 	if err := client.Logout(ctx); err != nil {
-		logger.Debug("gateway: token logout failed", "host", host, "error", err)
+		logger.Debug("gateway: token logout failed", "host", safeHost(host), "error", err)
 		return
 	}
-	logger.Debug("gateway: logged out cached token", "host", host)
+	logger.Debug("gateway: logged out cached token", "host", safeHost(host))
 }

--- a/server_test.go
+++ b/server_test.go
@@ -96,6 +96,66 @@ func TestGatewayServer_HostAllowlist(t *testing.T) {
 	})
 }
 
+// TestGatewayServer_RedactsUserinfoInHostLogs pins issue #41: a gateway host URL
+// can embed userinfo (https://user:pass@host), so every gateway host log field
+// must go through safeHost (url.Redacted) or an embedded credential leaks into the
+// logs (CWE-532). It drives representative reachable rejection paths; all gateway
+// host log fields share the same safeHost(host) wrapper.
+func TestGatewayServer_RedactsUserinfoInHostLogs(t *testing.T) {
+	t.Parallel()
+
+	const secret = "s3cr3tpw"
+
+	newReq := func(host string, withToken bool) *http.Request {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+		r.Header.Set("X-Centreon-Host", host)
+		if withToken {
+			r.Header.Set("X-Centreon-Token", "tok")
+		}
+		return r
+	}
+
+	allowlist := &Config{AllowedHosts: []string{"https://allowed.example.com"}}
+
+	tests := []struct {
+		name string
+		cfg  *Config
+		req  *http.Request
+	}{
+		// The host-not-in-allowlist path logs before validateHostScheme, so it sees
+		// the raw header for both the standard and the scheme-less credential form
+		// (the scheme-less form is the one url.Redacted alone would miss, issue #41).
+		{"scheme-ful host not in allowlist", allowlist, newReq("https://gwuser:"+secret+"@evil.example.com", true)},
+		{"scheme-less host not in allowlist", allowlist, newReq("gwuser:"+secret+"@evil.example.com", true)},
+		// empty allowlist + no credential headers -> missing-credentials path.
+		{"missing credentials", &Config{}, newReq("https://gwuser:"+secret+"@evil.example.com", false)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			cache := NewTokenCache(time.Minute)
+
+			if srv := gatewayServer(tt.req, tt.cfg, cache, logger, nil); srv != nil {
+				t.Fatal("expected nil server for a rejected gateway request")
+			}
+
+			out := buf.String()
+			if out == "" {
+				t.Fatal("expected a gateway log line, got none")
+			}
+			if strings.Contains(out, secret) {
+				t.Errorf("log leaked embedded password (CWE-532): %s", out)
+			}
+			if !strings.Contains(out, "gwuser:xxxxx@") {
+				t.Errorf("expected redacted host (url.Redacted) in log, got: %s", out)
+			}
+		})
+	}
+}
+
 // TestLogoutCachedToken_SendsTokenToLogoutEndpoint pins that logoutCachedToken
 // invalidates a specific Centreon session: it must call GET /logout with the
 // cached token in the X-AUTH-TOKEN header (the client sends its stored token),


### PR DESCRIPTION
## Summary

`gatewayServer` and `logoutCachedToken` logged the raw `X-Centreon-Host` value (and `runHTTP`/`runStdio` the raw `CENTREON_HOST`) at several sites. A host URL can embed userinfo (`https://user:pass@host`), so those lines could leak a credential into the logs (CWE-532). This routes every host-URL log field through `safeHost` so the redaction is uniform.

While wiring `safeHost` in everywhere, gate review found that `safeHost` itself failed open. `url.Redacted` only masks a parsed `//authority` userinfo, so a scheme-less `user:pass@host` (parsed as `scheme:opaque`), a password carrying an unescaped `/`, `?` or `#` (which breaks `url.Parse`), and an unparseable host all returned the credential verbatim. Because `safeHost` is also the sink for `validateHostScheme`'s rejection errors and the pre-allowlist "host not in allowlist" log, those forms leaked at ERROR level on caller-controlled input.

`safeHost` is redesigned to fail closed: redact the standard form via `url.Redacted`, the scheme-less form by reparsing as an authority, and any form `url.Parse` cannot decode into userinfo by masking the password span textually (`maskAuthorityPassword`). The early "well-formed URL, no userinfo" pass-through now requires a real host, so a password beginning with `/` is not mis-read as a credential-free path. A credential-free host is returned byte for byte unchanged, so log greps on the hostname still match.

The one documented residual is a password with an unencoded `//` or `://`, which is indistinguishable from URL scheme/authority structure; RFC 3986 requires percent-encoding such characters in userinfo.

## Related Issues

Closes #41

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean; `golangci-lint run ./...` 0 issues; `go test -race ./...` passes
- [x] `TestSafeHost` (25 cases): standard, scheme-less, special-char and leading-`/` passwords, unparseable input, plus no-corruption cases (path/query `:`/`@`, IPv6)
- [x] `TestGatewayServer_RedactsUserinfoInHostLogs`: scheme-ful and scheme-less credential hosts redacted at the pre-validation "host not in allowlist" sink
- [x] Validated against a leak/corruption corpus and a combinatorial fuzz (2100+ credential permutations): every realistic credential form redacts, zero realistic hosts corrupted