### PR TITLE
feat: add search, sort and poller filters to centreon_monitoring_resource_list (#52)

### DIFF
--- a/tools/monitoring_tools.go
+++ b/tools/monitoring_tools.go
@@ -2,7 +2,9 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
@@ -54,7 +56,7 @@ func RegisterMonitoringTools(s *mcp.Server, client *centreon.Client, logger *slo
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_monitoring_resource_list",
-		Description: "List hosts and services together in Centreon's unified resource view, each with its real-time monitoring status. Use this when you want hosts and services in one combined stream; for only hosts use centreon_monitoring_host_list and for only services use centreon_monitoring_service_list. Paginates with page (default 1) and limit (default 30, max 100) and reflects current engine state, not stored configuration. Read-only.",
+		Description: "List hosts and services together in Centreon's unified resource view, each with its real-time monitoring status. Use this when you want hosts and services in one combined stream; for only hosts use centreon_monitoring_host_list and for only services use centreon_monitoring_service_list. Optional filters: search (resource name, like match), hostName (a host and its services, like match), monitoringServer (exact poller name), plus sortBy (name, status, last_status_change) with sortOrder (ASC or DESC). Paginates with page (default 1) and limit (default 30, max 100) and reflects current engine state, not stored configuration. Read-only.",
 		Annotations: readOnlyTool("List monitoring resources"),
 	}, monitoringResourceListHandler(client, logger))
 
@@ -184,11 +186,108 @@ func monitoringServiceStatusCountsHandler(client *centreon.Client, logger *slog.
 	}
 }
 
-func monitoringResourceListHandler(client *centreon.Client, logger *slog.Logger) func(ctx context.Context, req *mcp.CallToolRequest, in MonitoringListInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, _ *mcp.CallToolRequest, in MonitoringListInput) (*mcp.CallToolResult, any, error) {
+// searchFieldName is the Centreon "name" search field, shared by the config-endpoint
+// search (buildListOptions) and the monitoring/resources search; sortDirAsc and
+// sortDirDesc are the accepted sort directions.
+const (
+	searchFieldName = "name"
+	sortDirAsc      = "ASC"
+	sortDirDesc     = "DESC"
+)
+
+// resourceSortFields maps user-facing sort keys to the Centreon monitoring/resources
+// sort fields. "status" sorts by severity. Field names verified against centreon-web
+// DbReadResourceRepository.php; NOT measured against a live instance.
+var resourceSortFields = map[string]string{
+	searchFieldName:      searchFieldName,
+	"status":             "status_severity_code",
+	"last_status_change": "last_status_change",
+}
+
+// MonitoringResourceListInput is the input for centreon_monitoring_resource_list.
+// The unified resources endpoint honors search and sort_by, so this tool exposes
+// name, host and poller filters plus sorting, unlike the other monitoring list tools.
+type MonitoringResourceListInput struct {
+	Page             int    `json:"page,omitempty"             jsonschema:"Page number (default 1)"`
+	Limit            int    `json:"limit,omitempty"            jsonschema:"Results per page (default 30, max 100)"`
+	Search           string `json:"search,omitempty"           jsonschema:"Filter by resource name (like match on host and service names)"`
+	HostName         string `json:"hostName,omitempty"         jsonschema:"Filter by host name (like match); matches the host and every service on it"`
+	MonitoringServer string `json:"monitoringServer,omitempty" jsonschema:"Filter by monitoring server (poller) name (exact match)"`
+	SortBy           string `json:"sortBy,omitempty"           jsonschema:"Sort field: name, status, or last_status_change (status sorts by severity)"`
+	SortOrder        string `json:"sortOrder,omitempty"        jsonschema:"Sort direction: ASC (default) or DESC; requires sortBy"`
+}
+
+// buildMonitoringResourceListOptions converts a MonitoringResourceListInput into
+// centreon.ListOption values for the unified monitoring/resources endpoint. It
+// returns an error for an invalid sort field or direction so the handler can
+// reject the request before calling the API.
+func buildMonitoringResourceListOptions(in *MonitoringResourceListInput) ([]centreon.ListOption, error) {
+	opts := pagingOptions(in.Page, in.Limit)
+	if f := buildResourceSearchFilter(in); f != nil {
+		opts = append(opts, centreon.WithSearch(f))
+	}
+	return appendResourceSort(opts, in.SortBy, in.SortOrder)
+}
+
+// buildResourceSearchFilter combines the optional name, host and poller filters in
+// a fixed order for deterministic output. It returns nil when no filter is set.
+func buildResourceSearchFilter(in *MonitoringResourceListInput) centreon.Filter {
+	var filters []centreon.Filter
+	if s := strings.TrimSpace(in.Search); s != "" {
+		filters = append(filters, centreon.Lk(searchFieldName, wrapLikePattern(s)))
+	}
+	if s := strings.TrimSpace(in.HostName); s != "" {
+		filters = append(filters, centreon.Lk("h.name", wrapLikePattern(s)))
+	}
+	if s := strings.TrimSpace(in.MonitoringServer); s != "" {
+		filters = append(filters, centreon.Eq("monitoring_server_name", s))
+	}
+	switch len(filters) {
+	case 0:
+		return nil
+	case 1:
+		return filters[0]
+	default:
+		return centreon.And(filters...)
+	}
+}
+
+// appendResourceSort appends a WithSort option for the given sort field and
+// direction. It leaves opts unchanged when sortBy is empty, and errors on an
+// unknown field, an invalid direction, or a direction supplied without a field.
+func appendResourceSort(opts []centreon.ListOption, sortBy, sortOrder string) ([]centreon.ListOption, error) {
+	sortBy = strings.TrimSpace(sortBy)
+	sortOrder = strings.TrimSpace(sortOrder)
+	if sortBy == "" {
+		if sortOrder != "" {
+			return nil, fmt.Errorf("sortOrder %q requires sortBy", sortOrder)
+		}
+		return opts, nil
+	}
+	field, ok := resourceSortFields[strings.ToLower(sortBy)]
+	if !ok {
+		return nil, fmt.Errorf("unknown sortBy %q (want name, status, or last_status_change)", sortBy)
+	}
+	dir := sortDirAsc
+	if sortOrder != "" {
+		dir = strings.ToUpper(sortOrder)
+		if dir != sortDirAsc && dir != sortDirDesc {
+			return nil, fmt.Errorf("invalid sortOrder %q (want ASC or DESC)", sortOrder)
+		}
+	}
+	return append(opts, centreon.WithSort(map[string]string{field: dir})), nil
+}
+
+func monitoringResourceListHandler(client *centreon.Client, logger *slog.Logger) func(ctx context.Context, req *mcp.CallToolRequest, in MonitoringResourceListInput) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, in MonitoringResourceListInput) (*mcp.CallToolResult, any, error) {
 		ctx = centreon.WithToolName(ctx, "centreon_monitoring_resource_list")
-		logger.Debug("centreon_monitoring_resource_list", "page", in.Page, "limit", in.Limit)
-		opts := buildMonitoringListOptions(in)
+		logger.Debug("centreon_monitoring_resource_list", "page", in.Page, "limit", in.Limit, "search", in.Search, "hostName", in.HostName, "monitoringServer", in.MonitoringServer, "sortBy", in.SortBy, "sortOrder", in.SortOrder)
+		opts, err := buildMonitoringResourceListOptions(&in)
+		if err != nil {
+			logger.Error("failed: centreon_monitoring_resource_list", "error", err)
+			res, anyVal := errorResult("centreon_monitoring_resource_list: invalid input: %v", err)
+			return res, anyVal, nil
+		}
 		resp, err := client.Monitoring.List(ctx, opts...)
 		if err != nil {
 			logger.Error("failed: centreon_monitoring_resource_list", "error", err)

--- a/tools/monitoring_tools_test.go
+++ b/tools/monitoring_tools_test.go
@@ -1,0 +1,274 @@
+package tools
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	centreon "github.com/tphakala/centreon-go-client"
+)
+
+// applyOpts applies functional list options to a fresh ListOptions so tests can
+// inspect the concrete search filter, sort map, page and limit that would be sent.
+func applyOpts(opts []centreon.ListOption) *centreon.ListOptions {
+	o := &centreon.ListOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// searchJSON marshals the built search filter to compact JSON for comparison.
+func searchJSON(t *testing.T, o *centreon.ListOptions) string {
+	t.Helper()
+	if o.Search == nil {
+		t.Fatal("expected a search filter, got nil")
+	}
+	b, err := json.Marshal(o.Search.Build())
+	if err != nil {
+		t.Fatalf("marshal search filter: %v", err)
+	}
+	return string(b)
+}
+
+func TestBuildMonitoringResourceListOptions_NoFiltersNoSearchParam(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	o := applyOpts(opts)
+	if o.Search != nil {
+		t.Errorf("expected no search filter, got %v", o.Search.Build())
+	}
+	if o.SortBy != nil {
+		t.Errorf("expected no sort, got %v", o.SortBy)
+	}
+	if o.Limit != 10 {
+		t.Errorf("limit = %d, want 10", o.Limit)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_SearchIsNameLike(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{Search: "web"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := searchJSON(t, applyOpts(opts))
+	want := `{"name":{"$lk":"%web%"}}`
+	if got != want {
+		t.Errorf("search = %s, want %s", got, want)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_HostNameUsesHName(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{HostName: "db01"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := searchJSON(t, applyOpts(opts))
+	want := `{"h.name":{"$lk":"%db01%"}}`
+	if got != want {
+		t.Errorf("search = %s, want %s", got, want)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_MonitoringServerIsEq(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{MonitoringServer: "Central"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := searchJSON(t, applyOpts(opts))
+	want := `{"monitoring_server_name":{"$eq":"Central"}}`
+	if got != want {
+		t.Errorf("search = %s, want %s", got, want)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_MultipleFiltersAndCombined(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{Search: "web", HostName: "db01"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := searchJSON(t, applyOpts(opts))
+	want := `{"$and":[{"name":{"$lk":"%web%"}},{"h.name":{"$lk":"%db01%"}}]}`
+	if got != want {
+		t.Errorf("search = %s, want %s", got, want)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_SortStatusDesc(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{SortBy: "status", SortOrder: "DESC"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	o := applyOpts(opts)
+	want := map[string]string{"status_severity_code": "DESC"}
+	if !reflect.DeepEqual(o.SortBy, want) {
+		t.Errorf("sortBy = %v, want %v", o.SortBy, want)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_SortDefaultsAscending(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{SortBy: "name"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	o := applyOpts(opts)
+	want := map[string]string{"name": "ASC"}
+	if !reflect.DeepEqual(o.SortBy, want) {
+		t.Errorf("sortBy = %v, want %v", o.SortBy, want)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_SortFieldCaseInsensitive(t *testing.T) {
+	// A mixed-case sort field must resolve via case-folding rather than erroring.
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{SortBy: "Status"})
+	if err != nil {
+		t.Fatalf("mixed-case sortBy should resolve, got error: %v", err)
+	}
+	if got := applyOpts(opts).SortBy; len(got) != 1 {
+		t.Errorf("expected exactly one sort key, got %v", got)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_SortOrderCaseInsensitive(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{SortBy: "name", SortOrder: "desc"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	o := applyOpts(opts)
+	want := map[string]string{"name": "DESC"}
+	if !reflect.DeepEqual(o.SortBy, want) {
+		t.Errorf("sortBy = %v, want %v", o.SortBy, want)
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_InvalidInput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   MonitoringResourceListInput
+	}{
+		{"unknown sortBy", MonitoringResourceListInput{SortBy: "bogus"}},
+		{"sortOrder without sortBy", MonitoringResourceListInput{SortOrder: "ASC"}},
+		{"bad sortOrder", MonitoringResourceListInput{SortBy: "name", SortOrder: "sideways"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := buildMonitoringResourceListOptions(&tc.in); err == nil {
+				t.Errorf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestBuildMonitoringResourceListOptions_WhitespaceInputsIgnored(t *testing.T) {
+	opts, err := buildMonitoringResourceListOptions(&MonitoringResourceListInput{Search: "   ", HostName: "\t", MonitoringServer: " "})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if o := applyOpts(opts); o.Search != nil {
+		t.Errorf("expected no search filter for whitespace-only inputs, got %v", o.Search.Build())
+	}
+}
+
+func TestMonitoringResourceListHandler_SendsSearchAndSortParams(t *testing.T) {
+	var gotPath, gotSearch, gotSort string
+	var calls atomic.Int64
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		gotPath = r.URL.Path
+		gotSearch = r.URL.Query().Get("search")
+		gotSort = r.URL.Query().Get("sort_by")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":[],"meta":{"page":1,"limit":30,"total":0}}`))
+	}))
+	defer fake.Close()
+
+	client, err := centreon.NewClient(fake.URL, centreon.WithAPIToken("t"))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	handler := monitoringResourceListHandler(client, testLogger(t))
+	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, MonitoringResourceListInput{Search: "web", SortBy: "name"})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", textOf(t, res))
+	}
+	if calls.Load() != 1 {
+		t.Errorf("expected 1 API call, got %d", calls.Load())
+	}
+	if !strings.HasSuffix(gotPath, "/monitoring/resources") {
+		t.Errorf("path = %q, want suffix /monitoring/resources", gotPath)
+	}
+	if gotSearch != `{"name":{"$lk":"%web%"}}` {
+		t.Errorf("search param = %q", gotSearch)
+	}
+	if gotSort != `{"name":"ASC"}` {
+		t.Errorf("sort_by param = %q", gotSort)
+	}
+}
+
+func TestMonitoringResourceListHandler_InvalidInputSkipsAPI(t *testing.T) {
+	var calls atomic.Int64
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write([]byte(`{"result":[],"meta":{}}`))
+	}))
+	defer fake.Close()
+
+	client, err := centreon.NewClient(fake.URL, centreon.WithAPIToken("t"))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	handler := monitoringResourceListHandler(client, testLogger(t))
+	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, MonitoringResourceListInput{SortBy: "name", SortOrder: "sideways"})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError for invalid input")
+	}
+	if !strings.Contains(textOf(t, res), "sideways") {
+		t.Errorf("error should mention the bad value, got %q", textOf(t, res))
+	}
+	if calls.Load() != 0 {
+		t.Errorf("expected 0 API calls for invalid input, got %d", calls.Load())
+	}
+}
+
+func TestWrapLikePattern(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"web", "%web%"},
+		{"%web%", "%web%"},
+		{"%web", "%web%"},
+		{"web%", "%web%"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := wrapLikePattern(tc.in); got != tc.want {
+			t.Errorf("wrapLikePattern(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBuildMonitoringListOptions_NeverAddsSearchOrSort(t *testing.T) {
+	o := applyOpts(buildMonitoringListOptions(MonitoringListInput{Page: 2, Limit: 10}))
+	if o.Search != nil {
+		t.Errorf("shared monitoring builder must not set search, got %v", o.Search.Build())
+	}
+	if o.SortBy != nil {
+		t.Errorf("shared monitoring builder must not set sort, got %v", o.SortBy)
+	}
+	if o.Limit != 10 || o.Page != 2 {
+		t.Errorf("limit/page = %d/%d, want 10/2", o.Limit, o.Page)
+	}
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -61,15 +61,15 @@ type ListInput struct {
 	Search string `json:"search,omitempty" jsonschema:"Filter by name (like match)"`
 }
 
-// MonitoringListInput is the input for monitoring list tools.
-// Monitoring endpoints do not support name search filtering.
+// MonitoringListInput is the input for the host and service monitoring list tools,
+// which support pagination only.
 type MonitoringListInput struct {
 	Page  int `json:"page,omitempty"  jsonschema:"Page number (default 1)"`
 	Limit int `json:"limit,omitempty" jsonschema:"Results per page (default 30, max 100)"`
 }
 
-// MonitoringHostIDListInput is the input for host-scoped monitoring list tools.
-// Monitoring endpoints do not support name search filtering.
+// MonitoringHostIDListInput is the input for host-scoped monitoring list tools
+// (host services and host timeline), which support pagination only.
 type MonitoringHostIDListInput struct {
 	HostID int `json:"hostID"           jsonschema:"Host ID"`
 	Page   int `json:"page,omitempty"   jsonschema:"Page number (default 1)"`
@@ -158,56 +158,52 @@ func errorResult(format string, args ...any) (res *mcp.CallToolResult, anyVal an
 	}, nil
 }
 
-// buildListOptions converts a ListInput into centreon.ListOption slice.
-// Search terms are automatically wrapped with SQL wildcards (%) for
-// consistent LIKE matching across all configuration endpoints.
-func buildListOptions(in ListInput) []centreon.ListOption {
-	var opts []centreon.ListOption
+// wrapLikePattern wraps s with SQL % wildcards for LIKE matching, unless a
+// wildcard is already present at that boundary. An empty string is unchanged.
+func wrapLikePattern(s string) string {
+	if s == "" {
+		return s
+	}
+	if s[0] != '%' {
+		s = "%" + s
+	}
+	if s[len(s)-1] != '%' {
+		s += "%"
+	}
+	return s
+}
 
-	limit := in.Limit
+// pagingOptions returns the clamped limit and optional page options shared by the
+// list builders. Limit defaults to defaultPageSize and is capped at maxPageSize.
+func pagingOptions(page, limit int) []centreon.ListOption {
 	if limit <= 0 {
 		limit = defaultPageSize
 	}
 	if limit > maxPageSize {
 		limit = maxPageSize
 	}
-	opts = append(opts, centreon.WithLimit(limit))
-
-	if in.Page > 0 {
-		opts = append(opts, centreon.WithPage(in.Page))
-	}
-	if in.Search != "" {
-		search := in.Search
-		if search != "" && search[0] != '%' {
-			search = "%" + search
-		}
-		if search != "" && search[len(search)-1] != '%' {
-			search += "%"
-		}
-		opts = append(opts, centreon.WithSearch(centreon.Lk("name", search)))
+	opts := []centreon.ListOption{centreon.WithLimit(limit)}
+	if page > 0 {
+		opts = append(opts, centreon.WithPage(page))
 	}
 	return opts
 }
 
-// buildMonitoringListOptions converts a MonitoringListInput into centreon.ListOption slice
-// for monitoring endpoints. Monitoring endpoints do not support the JSON search
-// filter format, so the search parameter is not accepted.
-func buildMonitoringListOptions(in MonitoringListInput) []centreon.ListOption {
-	var opts []centreon.ListOption
-
-	limit := in.Limit
-	if limit <= 0 {
-		limit = defaultPageSize
-	}
-	if limit > maxPageSize {
-		limit = maxPageSize
-	}
-	opts = append(opts, centreon.WithLimit(limit))
-
-	if in.Page > 0 {
-		opts = append(opts, centreon.WithPage(in.Page))
+// buildListOptions converts a ListInput into a centreon.ListOption slice. Search
+// terms are wrapped with SQL wildcards (%) for consistent LIKE matching across
+// configuration endpoints.
+func buildListOptions(in ListInput) []centreon.ListOption {
+	opts := pagingOptions(in.Page, in.Limit)
+	if in.Search != "" {
+		opts = append(opts, centreon.WithSearch(centreon.Lk(searchFieldName, wrapLikePattern(in.Search))))
 	}
 	return opts
+}
+
+// buildMonitoringListOptions converts a MonitoringListInput into a centreon.ListOption
+// slice for monitoring endpoints that support pagination only.
+func buildMonitoringListOptions(in MonitoringListInput) []centreon.ListOption {
+	return pagingOptions(in.Page, in.Limit)
 }
 
 // ListRequester abstracts any client List method.


### PR DESCRIPTION
## Summary

Adds optional server-side filtering and sorting to the read-only `centreon_monitoring_resource_list` tool. New optional inputs: `search` (resource name, like match), `hostName` (matches a host and its services), `monitoringServer` (exact poller name), plus `sortBy` (name, status, last_status_change) with `sortOrder` (ASC or DESC). These translate to the Centreon client's search Filter DSL and `sort_by`, which the unified `/monitoring/resources` endpoint honors. Previously the tool exposed only `page`/`limit`, so an agent could only page blindly through every resource, which is slow and token-heavy in large environments. This matches the flagship filtering the official Centreon MCP server offers.

Also refactors the shared list builders: `wrapLikePattern` and `pagingOptions` are extracted so the config and monitoring list builders route through one implementation (behavior preserved for the other tools), and three stale comments claiming "monitoring endpoints do not support name search filtering" are corrected, since the client itself uses `search` against those endpoints.

## Deferred (out of scope, needs a client change)

Status and type filters are intentionally deferred. Centreon's numeric status codes collide across hosts and services (DOWN and WARNING are both code 1; UNREACHABLE and CRITICAL both 2), so filtering by numeric `status_code` through the search DSL would be ambiguous. The correct, collision-free form is Centreon's dedicated name-based `statuses[]`/`types[]` params, which need `centreon-go-client` support first. The same applies to `hostgroup_names[]`, `servicegroup_names[]`, host/service category names, and multi-value monitoring-server filters. These will be a follow-up once the client exposes those params.

## Verification note

The search/sort field names (`name`, `h.name`, `monitoring_server_name`, `status_severity_code`, `last_status_change`) were verified against centreon-web source (`DbReadResourceRepository.php`, `ResourceFilter.php`) but NOT yet measured against a live Centreon instance. That endpoint silently ignores an unrecognized search field (returning unfiltered results rather than erroring), so a live smoke test is recommended before relying on the filters in production: call `centreon_monitoring_resource_list` with a `search`/`sortBy` and confirm `meta.search` echoes the filter and the result set is actually narrowed.

## Related issues

Relates to #52 (this PR delivers the search/sort/poller portion; status and group filters remain open there, pending the client change).

## Test plan

- [x] Unit tests for every filter and sort mapping, whitespace trimming, invalid-input rejection (skips the API), and back-compat of the shared paging builder. 15 tests, each sabotage-verified (proven to fail when its target production line is broken).
- [x] `go test ./...` green, `gofmt` clean, `golangci-lint run` reports 0 issues.
- [ ] Live smoke test against a real Centreon instance (see Verification note) before relying on the filters in production.