### PR TITLE
feat: expose the connected Centreon host in read-only tool responses

### DIFF
--- a/config.go
+++ b/config.go
@@ -266,11 +266,15 @@ func safeHost(host string) string {
 // display-path caller first runs the host through validateHostScheme, which
 // guarantees a parseable http/https URL, so the fail-closed placeholder is a
 // defensive fallback that never fires for a validated host.
+// redactedHostPlaceholder is the fail-closed display value for a host that has no
+// usable hostname, so a malformed or hostless input is never echoed verbatim.
+const redactedHostPlaceholder = "(redacted host)"
+
 func displayHost(host string) string {
-	if u, err := url.Parse(host); err == nil && u.Host != "" {
+	if u, err := url.Parse(host); err == nil && u.Hostname() != "" {
 		return u.Scheme + "://" + u.Host
 	}
-	return "(redacted host)"
+	return redactedHostPlaceholder
 }
 
 // maskAuthorityPassword fails closed for host strings url.Parse cannot decode into

--- a/config.go
+++ b/config.go
@@ -258,6 +258,21 @@ func safeHost(host string) string {
 	return maskAuthorityPassword(host)
 }
 
+// displayHost reduces a host URL to scheme://host[:port] for display in a tool
+// response, stripping ALL userinfo (username and password) plus any path, query
+// and fragment, so no credential embedded in the URL reaches a client. This is
+// stricter than safeHost, which keeps the username for log greps: issue #48
+// requires the response to expose no username, password or token. Every
+// display-path caller first runs the host through validateHostScheme, which
+// guarantees a parseable http/https URL, so the fail-closed placeholder is a
+// defensive fallback that never fires for a validated host.
+func displayHost(host string) string {
+	if u, err := url.Parse(host); err == nil && u.Host != "" {
+		return u.Scheme + "://" + u.Host
+	}
+	return "(redacted host)"
+}
+
 // maskAuthorityPassword fails closed for host strings url.Parse cannot decode into
 // userinfo (a password with an unescaped '/', '?' or '#', a leading "://", or an
 // invalid percent-escape). It masks the password span from the first ':' to the

--- a/config_test.go
+++ b/config_test.go
@@ -355,7 +355,8 @@ func TestDisplayHost(t *testing.T) {
 		// host:port; displayHost still does not leak the "secret" password span, and
 		// this malformed form is not reachable through the success-gated tool sink.
 		{"does not leak password on the numeric-prefix form", "https://admin:1234/secret@centreon.example.com", "https://admin:1234"},
-		{"fails closed on empty", "", "(redacted host)"},
+		{"fails closed on empty", "", redactedHostPlaceholder},
+		{"fails closed on a hostless authority", "https://:8443", redactedHostPlaceholder},
 	}
 
 	for _, tt := range tests {

--- a/config_test.go
+++ b/config_test.go
@@ -334,6 +334,39 @@ func TestSafeHost(t *testing.T) {
 	}
 }
 
+// TestDisplayHost pins that displayHost reduces a host URL to scheme://host[:port]
+// for a tool response, stripping the username as well as the password (issue #48
+// requires no username/password/token in the response), unlike safeHost which
+// keeps the username for log greps.
+func TestDisplayHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"strips username and password", "https://gwuser:sekret@centreon.example.com", "https://centreon.example.com"},
+		{"strips username-only userinfo", "https://gwuser@centreon.example.com", "https://centreon.example.com"},
+		{"strips userinfo over http", "http://admin:sekret@centreon.example.com", "http://centreon.example.com"},
+		{"keeps host and port", "https://centreon.example.com:8443", "https://centreon.example.com:8443"},
+		{"strips path and query", "https://centreon.example.com:8443/mon?q=1", "https://centreon.example.com:8443"},
+		{"strips userinfo with port and path", "https://admin:sekret@centreon.example.com:8443/mon", "https://centreon.example.com:8443"},
+		{"leaves plain host unchanged", "https://centreon.example.com", "https://centreon.example.com"},
+		// The numeric-prefix userinfo form (issue #55) is mis-parsed by url.Parse as
+		// host:port; displayHost still does not leak the "secret" password span, and
+		// this malformed form is not reachable through the success-gated tool sink.
+		{"does not leak password on the numeric-prefix form", "https://admin:1234/secret@centreon.example.com", "https://admin:1234"},
+		{"fails closed on empty", "", "(redacted host)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := displayHost(tt.host); got != tt.want {
+				t.Errorf("displayHost(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestLoadConfig_HostScheme pins that CENTREON_HOST is scheme-checked at load,
 // gated by CENTREON_ALLOW_HTTP, and skipped only in HTTP gateway mode where the
 // host is an unused placeholder. It also pins that stdio+gateway still validates,

--- a/server.go
+++ b/server.go
@@ -51,13 +51,15 @@ const (
 	gatewayLogoutConcurrency = 16
 )
 
-// buildServer creates an MCP server with all tools registered.
-func buildServer(client *centreon.Client, logger *slog.Logger) *mcp.Server {
+// buildServer creates an MCP server with all tools registered. displayHost is
+// the Centreon host the status and connection tools report; the caller must
+// already have passed it through safeHost, as buildServer does not redact.
+func buildServer(client *centreon.Client, logger *slog.Logger, displayHost string) *mcp.Server {
 	s := mcp.NewServer(
 		&mcp.Implementation{Name: "centreon-mcp-go", Version: version},
 		&mcp.ServerOptions{Instructions: serverInstructions},
 	)
-	tools.RegisterAll(s, client, logger)
+	tools.RegisterAll(s, client, logger, displayHost)
 	return s
 }
 
@@ -202,7 +204,7 @@ func runStdio(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient 
 		logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
 	}
 
-	s := buildServer(client, logger)
+	s := buildServer(client, logger, safeHost(cfg.Host))
 	logger.Info("centreon-mcp-go ready", "transport", "stdio")
 	return s.Run(ctx, &mcp.StdioTransport{})
 }
@@ -234,6 +236,10 @@ func logoutClientBounded(ctx context.Context, client *centreon.Client, logger *s
 func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *http.Client) error {
 	var sharedClient *centreon.Client
 	var tokenCache *TokenCache
+	// envDisplayHost is the redacted host the tools report in env mode; computed
+	// once here rather than per request. In gateway mode the per-request host is
+	// used instead (see gatewayServer), so this stays empty.
+	var envDisplayHost string
 
 	if cfg.AuthMode == authModeEnv {
 		client, err := newCentreonClient(cfg.Host, cfg, logger, httpClient)
@@ -247,6 +253,7 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 			logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
 		}
 		sharedClient = client
+		envDisplayHost = safeHost(cfg.Host)
 	} else {
 		tokenCache = NewTokenCache(tokenCacheTTL)
 		if len(cfg.AllowedHosts) == 0 {
@@ -258,7 +265,7 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 
 	getServer := func(r *http.Request) *mcp.Server {
 		if cfg.AuthMode == authModeEnv {
-			return buildServer(sharedClient, logger)
+			return buildServer(sharedClient, logger, envDisplayHost)
 		}
 		return gatewayServer(r, cfg, tokenCache, logger, httpClient)
 	}
@@ -407,8 +414,9 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		}
 	}
 
-	logger.Debug("gateway: created per-request client", "host", safeHost(host))
-	return buildServer(client, logger)
+	safeHostName := safeHost(host)
+	logger.Debug("gateway: created per-request client", "host", safeHostName)
+	return buildServer(client, logger, safeHostName)
 }
 
 // hostAllowed reports whether host may be used in gateway mode. An empty

--- a/server.go
+++ b/server.go
@@ -51,15 +51,16 @@ const (
 	gatewayLogoutConcurrency = 16
 )
 
-// buildServer creates an MCP server with all tools registered. displayHost is
-// the Centreon host the status and connection tools report; the caller must
-// already have passed it through safeHost, as buildServer does not redact.
-func buildServer(client *centreon.Client, logger *slog.Logger, displayHost string) *mcp.Server {
+// buildServer creates an MCP server with all tools registered. displayHostName
+// is the Centreon host the status and connection tools report; the caller must
+// already have passed it through displayHost (which strips all userinfo), as
+// buildServer does not sanitize.
+func buildServer(client *centreon.Client, logger *slog.Logger, displayHostName string) *mcp.Server {
 	s := mcp.NewServer(
 		&mcp.Implementation{Name: "centreon-mcp-go", Version: version},
 		&mcp.ServerOptions{Instructions: serverInstructions},
 	)
-	tools.RegisterAll(s, client, logger, displayHost)
+	tools.RegisterAll(s, client, logger, displayHostName)
 	return s
 }
 
@@ -204,7 +205,7 @@ func runStdio(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient 
 		logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
 	}
 
-	s := buildServer(client, logger, safeHost(cfg.Host))
+	s := buildServer(client, logger, displayHost(cfg.Host))
 	logger.Info("centreon-mcp-go ready", "transport", "stdio")
 	return s.Run(ctx, &mcp.StdioTransport{})
 }
@@ -253,7 +254,7 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 			logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
 		}
 		sharedClient = client
-		envDisplayHost = safeHost(cfg.Host)
+		envDisplayHost = displayHost(cfg.Host)
 	} else {
 		tokenCache = NewTokenCache(tokenCacheTTL)
 		if len(cfg.AllowedHosts) == 0 {
@@ -414,9 +415,8 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		}
 	}
 
-	safeHostName := safeHost(host)
-	logger.Debug("gateway: created per-request client", "host", safeHostName)
-	return buildServer(client, logger, safeHostName)
+	logger.Debug("gateway: created per-request client", "host", safeHost(host))
+	return buildServer(client, logger, displayHost(host))
 }
 
 // hostAllowed reports whether host may be used in gateway mode. An empty

--- a/server_test.go
+++ b/server_test.go
@@ -14,6 +14,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestHostAllowed(t *testing.T) {
@@ -560,6 +562,90 @@ func TestGatewayServer_TokenCachePinsPassword(t *testing.T) {
 	}
 	if n := atomic.LoadInt32(&loginCount); n != 2 {
 		t.Fatalf("request 3: wrong password must force a fresh login (expected 2 total), got %d", n)
+	}
+}
+
+// callToolText extracts the first text content from a tool result.
+func callToolText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) == 0 {
+		t.Fatal("result has no content")
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content is %T, want *mcp.TextContent", res.Content[0])
+	}
+	return tc.Text
+}
+
+// TestGatewayServer_ToolResponseReportsRedactedHost is an end-to-end guard for
+// #48: it drives gatewayServer with an X-Centreon-Host that embeds credentials,
+// then calls centreon_connection_test over an in-memory MCP session and asserts
+// the response names the per-request host with the password redacted, leaking
+// neither the password nor the token. This pins both the gateway threading and
+// the redaction at the gateway buildServer call site: passing the raw host
+// leaks the password, while passing cfg.Host (the gateway placeholder) drops the
+// loopback host:port. Either regression turns this red.
+func TestGatewayServer_ToolResponseReportsRedactedHost(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	const (
+		secret = "sup3r-s3cret-pass"
+		token  = "tok-abc"
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	hostPort := strings.TrimPrefix(srv.URL, "http://")
+	hostWithCreds := "http://gwuser:" + secret + "@" + hostPort
+
+	cfg := &Config{AllowHTTP: true} // empty allowlist accepts any host; loopback http
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+	req.Header.Set("X-Centreon-Host", hostWithCreds)
+	req.Header.Set("X-Centreon-Token", token)
+
+	s := gatewayServer(req, cfg, NewTokenCache(time.Minute), logger, nil)
+	if s == nil {
+		t.Fatal("gatewayServer returned nil")
+	}
+
+	ctx := t.Context()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	ss, err := s.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "issue48-test", Version: "0"}, nil)
+	cs, err := c.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "centreon_connection_test"})
+	if err != nil {
+		t.Fatalf("call tool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("connection test reported an error: %s", callToolText(t, res))
+	}
+
+	text := callToolText(t, res)
+	if want := "gwuser:xxxxx@" + hostPort; !strings.Contains(text, want) {
+		t.Errorf("response should name the redacted per-request host %q, got: %q", want, text)
+	}
+	if strings.Contains(text, secret) {
+		t.Errorf("response leaked the password, got: %q", text)
+	}
+	if strings.Contains(text, token) {
+		t.Errorf("response leaked the token, got: %q", text)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -581,11 +581,12 @@ func callToolText(t *testing.T, res *mcp.CallToolResult) string {
 // TestGatewayServer_ToolResponseReportsRedactedHost is an end-to-end guard for
 // #48: it drives gatewayServer with an X-Centreon-Host that embeds credentials,
 // then calls centreon_connection_test over an in-memory MCP session and asserts
-// the response names the per-request host with the password redacted, leaking
-// neither the password nor the token. This pins both the gateway threading and
-// the redaction at the gateway buildServer call site: passing the raw host
-// leaks the password, while passing cfg.Host (the gateway placeholder) drops the
-// loopback host:port. Either regression turns this red.
+// the response names the per-request host with ALL userinfo stripped, leaking
+// neither the username, the password, nor the token. This pins both the gateway
+// threading and the display-host sanitization at the gateway buildServer call
+// site: passing safeHost(host) leaks the username, passing the raw host leaks the
+// password, and passing cfg.Host (the gateway placeholder) drops the loopback
+// host:port. Each regression turns this red.
 func TestGatewayServer_ToolResponseReportsRedactedHost(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 
@@ -638,8 +639,11 @@ func TestGatewayServer_ToolResponseReportsRedactedHost(t *testing.T) {
 	}
 
 	text := callToolText(t, res)
-	if want := "gwuser:xxxxx@" + hostPort; !strings.Contains(text, want) {
-		t.Errorf("response should name the redacted per-request host %q, got: %q", want, text)
+	if want := "http://" + hostPort; !strings.Contains(text, want) {
+		t.Errorf("response should name the per-request host %q, got: %q", want, text)
+	}
+	if strings.Contains(text, "gwuser") {
+		t.Errorf("response leaked the username, got: %q", text)
 	}
 	if strings.Contains(text, secret) {
 		t.Errorf("response leaked the password, got: %q", text)

--- a/tools/connection_tools.go
+++ b/tools/connection_tools.go
@@ -8,26 +8,36 @@ import (
 	centreon "github.com/tphakala/centreon-go-client"
 )
 
-// RegisterConnectionTools registers all connection tools.
-func RegisterConnectionTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
+// RegisterConnectionTools registers all connection tools. host is the
+// credential-redacted Centreon host named in the success result; the caller
+// supplies it already redacted (see RegisterAll).
+func RegisterConnectionTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger, host string) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_connection_test",
-		Description: "Verify that the configured Centreon API credentials authenticate and the API is reachable by fetching host status counts. Takes no arguments; call this first to confirm connectivity before using other tools. Read-only.",
+		Description: "Verify that the configured Centreon API credentials authenticate and the API is reachable by fetching host status counts. On success the result names the connected Centreon host, with any embedded credentials redacted. Takes no arguments; call this first to confirm connectivity before using other tools. Read-only.",
 		Annotations: readOnlyTool("Test connection"),
-	}, connectionTestHandler(client, logger))
+	}, connectionTestHandler(client, logger, host))
 }
 
-func connectionTestHandler(client *centreon.Client, logger *slog.Logger) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+func connectionTestHandler(client *centreon.Client, logger *slog.Logger, host string) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+	return connectionTestHandlerFn(client.MonitoringHosts.StatusCounts, logger, host)
+}
+
+// connectionTestHandlerFn builds the connection-test handler from the status
+// fetch as a function value, so it is unit-testable without a live client. host
+// is the already-redacted display host named on success; it is never included on
+// the failure path, and no credential ever reaches it.
+func connectionTestHandlerFn(fetchStatus func(context.Context) (*centreon.HostStatusCount, error), logger *slog.Logger, host string) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		ctx = centreon.WithToolName(ctx, "centreon_connection_test")
 		logger.Debug("centreon_connection_test")
-		_, err := client.MonitoringHosts.StatusCounts(ctx)
+		_, err := fetchStatus(ctx)
 		if err != nil {
 			logger.Error("failed: centreon_connection_test", "error", err)
 			res, anyVal := errorResult("connection failed: %v", err)
 			return res, anyVal, nil
 		}
-		res, anyVal := textResult("Connection successful")
+		res, anyVal := textResult("Connection successful (host: %s)", host)
 		return res, anyVal, nil
 	}
 }

--- a/tools/connection_tools_test.go
+++ b/tools/connection_tools_test.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	centreon "github.com/tphakala/centreon-go-client"
+)
+
+// TestConnectionTestHandlerFn_SuccessReportsHost pins that a successful
+// connection test names the configured host in its text result. The host is
+// passed in already redacted (the caller runs it through safeHost), so the
+// handler prints it verbatim.
+func TestConnectionTestHandlerFn_SuccessReportsHost(t *testing.T) {
+	fetch := func(context.Context) (*centreon.HostStatusCount, error) {
+		return &centreon.HostStatusCount{}, nil
+	}
+
+	handler := connectionTestHandlerFn(fetch, testLogger(t), "https://centreon.example.com")
+	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error result: %s", textOf(t, res))
+	}
+	if got, want := textOf(t, res), "Connection successful (host: https://centreon.example.com)"; got != want {
+		t.Errorf("result text = %q, want %q", got, want)
+	}
+}
+
+// TestConnectionTestHandlerFn_ErrorOmitsHost pins that a failed connection test
+// reports the error without the host string, so the failure path cannot surface
+// the host. Credential redaction on the success path is covered by the gateway
+// end-to-end test in the main package.
+func TestConnectionTestHandlerFn_ErrorOmitsHost(t *testing.T) {
+	fetch := func(context.Context) (*centreon.HostStatusCount, error) {
+		return nil, errors.New("boom")
+	}
+
+	handler := connectionTestHandlerFn(fetch, testLogger(t), "https://centreon.example.com")
+	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error result")
+	}
+	if got, want := textOf(t, res), "connection failed: boom"; got != want {
+		t.Errorf("result text = %q, want %q", got, want)
+	}
+}

--- a/tools/status_tools.go
+++ b/tools/status_tools.go
@@ -14,8 +14,8 @@ import (
 // PlatformStatus combines host status counts, service status counts, and monitoring servers.
 type PlatformStatus struct {
 	// Host is the configured Centreon host, with any embedded credentials
-	// redacted (the caller passes it through safeHost); it names the instance the
-	// counts below describe.
+	// stripped (the caller passes it through displayHost); it names the instance
+	// the counts below describe.
 	Host     string                                            `json:"host"`
 	Hosts    *centreon.HostStatusCount                         `json:"hosts"`
 	Services *centreon.ServiceStatusCount                      `json:"services"`

--- a/tools/status_tools.go
+++ b/tools/status_tools.go
@@ -13,18 +13,24 @@ import (
 
 // PlatformStatus combines host status counts, service status counts, and monitoring servers.
 type PlatformStatus struct {
+	// Host is the configured Centreon host, with any embedded credentials
+	// redacted (the caller passes it through safeHost); it names the instance the
+	// counts below describe.
+	Host     string                                            `json:"host"`
 	Hosts    *centreon.HostStatusCount                         `json:"hosts"`
 	Services *centreon.ServiceStatusCount                      `json:"services"`
 	Servers  *centreon.ListResponse[centreon.MonitoringServer] `json:"servers"`
 }
 
-// RegisterStatusTools registers all platform status tools.
-func RegisterStatusTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
+// RegisterStatusTools registers all platform status tools. host is the
+// credential-redacted Centreon host reported in the response; the caller
+// supplies it already redacted (see RegisterAll).
+func RegisterStatusTools(s *mcp.Server, client *centreon.Client, logger *slog.Logger, host string) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "centreon_platform_status",
-		Description: "Return a combined live platform overview in one call: host status counts (up/down/unreachable), service status counts (ok/warning/critical/unknown), and the list of monitoring servers. Use this for an at-a-glance health snapshot; for the individual pieces use centreon_monitoring_host_status_counts, centreon_monitoring_service_status_counts, or centreon_server_list. Read-only.",
+		Description: "Return a combined live platform overview in one call: host status counts (up/down/unreachable), service status counts (ok/warning/critical/unknown), and the list of monitoring servers. The response also names the configured Centreon host (credentials redacted). Use this for an at-a-glance health snapshot; for the individual pieces use centreon_monitoring_host_status_counts, centreon_monitoring_service_status_counts, or centreon_server_list. Read-only.",
 		Annotations: readOnlyTool("Platform status"),
-	}, platformStatusHandler(client, logger))
+	}, platformStatusHandler(client, logger, host))
 }
 
 // logReadError logs a failed platform-status read at Error level, unless the
@@ -40,7 +46,7 @@ func logReadError(logger *slog.Logger, part, msg string, err error) error {
 	return fmt.Errorf("%s: %w", msg, err)
 }
 
-func platformStatusHandler(client *centreon.Client, logger *slog.Logger) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+func platformStatusHandler(client *centreon.Client, logger *slog.Logger, host string) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
 	return platformStatusHandlerFn(
 		client.MonitoringHosts.StatusCounts,
 		client.MonitoringServices.StatusCounts,
@@ -48,6 +54,7 @@ func platformStatusHandler(client *centreon.Client, logger *slog.Logger) func(ct
 			return client.MonitoringServers.List(ctx)
 		},
 		logger,
+		host,
 	)
 }
 
@@ -60,6 +67,7 @@ func platformStatusHandlerFn(
 	fetchServices func(context.Context) (*centreon.ServiceStatusCount, error),
 	fetchServers func(context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error),
 	logger *slog.Logger,
+	host string,
 ) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		ctx = centreon.WithToolName(ctx, "centreon_platform_status")
@@ -104,6 +112,7 @@ func platformStatusHandlerFn(
 		}
 
 		status := PlatformStatus{
+			Host:     host,
 			Hosts:    hosts,
 			Services: services,
 			Servers:  servers,

--- a/tools/status_tools_test.go
+++ b/tools/status_tools_test.go
@@ -34,6 +34,10 @@ func (h *errorCountHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
 
 func (h *errorCountHandler) WithGroup(string) slog.Handler { return h }
 
+// testStatusHost is the already-redacted display host threaded into the status
+// handler under test; the handler must surface it verbatim.
+const testStatusHost = "https://centreon.example.com"
+
 // textOf extracts the first text content from a tool result.
 func textOf(t *testing.T, res *mcp.CallToolResult) string {
 	t.Helper()
@@ -64,7 +68,7 @@ func TestPlatformStatusHandlerFn_CombinesResults(t *testing.T) {
 		}, nil
 	}
 
-	handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t))
+	handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t), testStatusHost)
 	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -88,6 +92,9 @@ func TestPlatformStatusHandlerFn_CombinesResults(t *testing.T) {
 	}
 	if got.Servers == nil || len(got.Servers.Result) != 1 || got.Servers.Result[0].Name != "poller-7" {
 		t.Errorf("servers not placed correctly: %+v", got.Servers)
+	}
+	if got.Host != testStatusHost {
+		t.Errorf("host = %q, want %q", got.Host, testStatusHost)
 	}
 }
 
@@ -115,7 +122,7 @@ func TestPlatformStatusHandlerFn_RunsConcurrently(t *testing.T) {
 		return &centreon.ListResponse[centreon.MonitoringServer]{}, nil
 	}
 
-	handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t))
+	handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t), testStatusHost)
 	done := make(chan struct{})
 	go func() {
 		_, _, _ = handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
@@ -182,7 +189,7 @@ func TestPlatformStatusHandlerFn_ReportsError(t *testing.T) {
 				}
 			}
 
-			handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t))
+			handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t), testStatusHost)
 			res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -190,8 +197,12 @@ func TestPlatformStatusHandlerFn_ReportsError(t *testing.T) {
 			if !res.IsError {
 				t.Fatal("expected error result")
 			}
-			if text := textOf(t, res); !strings.Contains(text, tt.wantMessage) {
+			text := textOf(t, res)
+			if !strings.Contains(text, tt.wantMessage) {
 				t.Errorf("error result should identify the failing call %q, got: %q", tt.wantMessage, text)
+			}
+			if strings.Contains(text, testStatusHost) {
+				t.Errorf("error result should not include the host, got: %q", text)
 			}
 		})
 	}
@@ -221,7 +232,7 @@ func TestPlatformStatusHandlerFn_SuppressesCancellationLogs(t *testing.T) {
 		return nil, ctx.Err()
 	}
 
-	h := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, logger)
+	h := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, logger, testStatusHost)
 	res, _, err := h(t.Context(), &mcp.CallToolRequest{}, struct{}{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/tools/tdqs_test.go
+++ b/tools/tdqs_test.go
@@ -60,7 +60,7 @@ func TestTDQS_ToolDefinitionsQuality(t *testing.T) {
 	ctx := t.Context()
 
 	s := mcp.NewServer(&mcp.Implementation{Name: "centreon-mcp-go", Version: "test"}, nil)
-	RegisterAll(s, &centreon.Client{}, nil)
+	RegisterAll(s, &centreon.Client{}, nil, "https://tdqs.example.com")
 
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
 	ss, err := s.Connect(ctx, serverTransport, nil)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -17,8 +17,8 @@ const (
 
 // RegisterAll registers all Centreon tools with the MCP server. host is the
 // display-only Centreon host surfaced by the status and connection tools; it
-// must already be credential-redacted by the caller (safeHost in package main),
-// as the tools package prints it verbatim and never redacts.
+// must already be stripped of credentials by the caller (displayHost in package
+// main removes all userinfo), as the tools package prints it verbatim.
 func RegisterAll(s *mcp.Server, client *centreon.Client, logger *slog.Logger, host string) {
 	if logger == nil {
 		logger = slog.Default()

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -15,8 +15,11 @@ const (
 	defaultPageSize = 30
 )
 
-// RegisterAll registers all Centreon tools with the MCP server.
-func RegisterAll(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
+// RegisterAll registers all Centreon tools with the MCP server. host is the
+// display-only Centreon host surfaced by the status and connection tools; it
+// must already be credential-redacted by the caller (safeHost in package main),
+// as the tools package prints it verbatim and never redacts.
+func RegisterAll(s *mcp.Server, client *centreon.Client, logger *slog.Logger, host string) {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -29,8 +32,8 @@ func RegisterAll(s *mcp.Server, client *centreon.Client, logger *slog.Logger) {
 	RegisterInfraTools(s, client, logger)
 	RegisterUserTools(s, client, logger)
 	RegisterNotificationTools(s, client, logger)
-	RegisterStatusTools(s, client, logger)
-	RegisterConnectionTools(s, client, logger)
+	RegisterStatusTools(s, client, logger, host)
+	RegisterConnectionTools(s, client, logger, host)
 }
 
 // readOnlyTool annotates a tool that only reads from the Centreon API (open world).


### PR DESCRIPTION
## Summary

`centreon_connection_test` now names the connected Centreon host on success, and `centreon_platform_status` returns it as a top-level `host` field, so an MCP client can confirm which Centreon instance it is talking to. Previously the host was only visible in the server's own startup logs, never in a tool result.

The host shown to clients is sanitized by a new `displayHost` helper (package `main`), which reduces the URL to `scheme://host[:port]` and strips all userinfo (username and password) plus any path, query and fragment, so no credential embedded in the URL is ever returned (issue #48 requires the response to expose no username, password or token). The sanitized string is threaded as display-only through `buildServer` and `tools.RegisterAll` into the two tools; the `tools` package prints it verbatim and never sanitizes. In gateway mode the per-request `X-Centreon-Host` is reported (not the unused `cfg.Host` placeholder), so a multi-tenant caller sees the instance its own request targeted. The existing `safeHost` helper (which keeps the username for log greps, issue #41) is unchanged and still used for the log lines.

## Related issues

Closes #48.

Filed #55 during review: a pre-existing `safeHost` fail-open on a userinfo password whose first segment is numeric before an unencoded `/`, `?` or `#`. It is not practically reachable through the tool-response sinks added here (those render the host only on connection success, and that malformed-URL class breaks the connection), so it is tracked separately rather than fixed in this feature PR.

## Test plan

- [x] `go test -race ./...` (unit tests for `displayHost` and both tools, plus an end-to-end gateway test that drives the real `gatewayServer` over an in-memory MCP session and asserts the username, password and token are all absent while the sanitized host is present)
- [x] `golangci-lint run ./...`, `gofmt`, `go vet` all clean
- [x] `TestTDQS_ToolDefinitionsQuality` still passes (tool count unchanged; both edited descriptions keep the `Read-only.` marker and contain no dashes)
- [x] Each new assertion sabotage-verified against the production line it pins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Centreon hosts shown in connection and status responses now redact credentials and remove sensitive URL details.
  * Failed connection and status responses avoid exposing host information.

* **Improvements**
  * Connection tests report the configured, sanitized Centreon host on success.
  * Platform status information includes the sanitized host for clearer connection context across server modes.

* **Tests**
  * Added coverage for credential redaction, successful host reporting, gateway responses, and secure error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->