### PR TITLE
fix: fail closed when url.Parse mis-reads userinfo in a host URL (#55)

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -203,22 +204,18 @@ func gatewayMode(cfg *Config) bool {
 // exposes them on the wire (CWE-319). https is always accepted; http only when the
 // operator opts in via CENTREON_ALLOW_HTTP. A missing or non-http(s) scheme, or an
 // unparseable URL, is rejected outright (fail closed). url.Parse normalises the
-// scheme to lowercase, so the cases below are matched in lowercase. A host that
-// still contains a raw '@' the parser did not consume as userinfo is also rejected:
-// it is a mis-encoded credential or a malformed base URL either way (issue #55).
+// scheme to lowercase, so the cases below are matched in lowercase.
 func validateHostScheme(host string, allowHTTP bool) error {
 	u, err := url.Parse(host)
 	if err != nil {
-		return fmt.Errorf("invalid host url %q: %w", safeHost(host), err)
-	}
-	// url.Parse can accept a mis-encoded credential without reporting userinfo: an
-	// all-numeric password prefix parses as a port and a short username as the host,
-	// leaving the '@' in the path, query or fragment (issue #55). A Centreon base URL
-	// never contains a raw '@', so reject the whole class rather than let the
-	// mis-parsed authority become a live client. Gated on http(s) so a scheme problem
-	// keeps its own more specific message.
-	if (u.Scheme == schemeHTTPS || u.Scheme == schemeHTTP) && u.User == nil && strings.ContainsRune(host, '@') {
-		return fmt.Errorf("host %q contains an unencoded '@' after the authority: percent-encode userinfo characters (RFC 3986) or remove the credential", safeHost(host))
+		// url.Error.Error() embeds the URL it failed on, so wrapping err directly
+		// would reprint the raw credential that safeHost just masked in the same
+		// message (CWE-532). Wrap only the reason.
+		reason := err
+		if urlErr, ok := errors.AsType[*url.Error](err); ok {
+			reason = urlErr.Err
+		}
+		return fmt.Errorf("invalid host url %q: %w", safeHost(host), reason)
 	}
 	switch u.Scheme {
 	case schemeHTTPS:
@@ -240,41 +237,86 @@ func validateHostScheme(host string, allowHTTP bool) error {
 // standard scheme://user:pass@host form via url.Redacted and the scheme-less
 // user:pass@host form (which url.Parse treats as scheme:opaque, exposing no userinfo
 // to mask) by reparsing it as an authority. url.Parse can also mis-read intended
-// userinfo without failing: an all-numeric password prefix parses as a port and a
-// short username parses as the host, leaving the credential in the path, query or
-// fragment (issue #55). An input that parses without userinfo but still carries a
-// raw '@' therefore falls through to be masked, except a parsed bracketed IPv6
-// authority, which can never be userinfo. A host with no '@' is returned unchanged,
-// and masking only ever replaces the span between the first ':' and the last '@',
-// so the hostname survives and log greps on it still match. Every host-URL log field
-// and validateHostScheme error message routes through it.
+// userinfo without failing: an all-numeric password prefix parses as a port, a short
+// username parses as the host, and an email-style username makes the authority split
+// land on the wrong '@', each leaving the credential in the path, query or fragment
+// (issue #55). Any input those forms could describe falls through to be masked, so a
+// host is returned unchanged only when no reading of it places a password span in
+// the tail. Every host-URL log field and error message in this package routes
+// through it.
 //
 // Limitation: a password containing an unencoded "//" or "://" is indistinguishable
-// from URL scheme/authority structure (url.Parse reads it as a scheme and username),
+// from URL scheme/authority structure (url.Parse reads it as a scheme and an opaque
+// remainder, and the textual masker then treats the "//" as the authority marker),
 // so it may not be fully masked. RFC 3986 requires percent-encoding such characters
 // in userinfo; the realistic single-'/' base64 case is handled.
 func safeHost(host string) string {
 	if u, err := url.Parse(host); err == nil {
 		if u.User != nil {
-			return u.Redacted()
-		}
-		// A parsed URL with no userinfo can still be a mis-read credential: url.Parse
-		// turns user:digits into host:port and a short username into the host, leaving
-		// the '@' in the path, query or fragment (issue #55). Returning unchanged is
-		// only safe when the input carries no raw '@' at all, or when the parsed host
-		// is a bracketed IPv6 literal: '[' is an RFC 3986 gen-delim and invalid in
-		// userinfo, and an '@' inside a bracketed authority makes url.Parse fail with
-		// "invalid userinfo" rather than reach here. Anything else falls through to
-		// be masked.
-		if u.Opaque == "" && u.Host != "" && !strings.HasSuffix(u.Host, ":") &&
-			(!strings.ContainsRune(host, '@') || strings.HasPrefix(u.Host, "[")) {
+			if redactedCoversCredential(u, host) {
+				return u.Redacted()
+			}
+		} else if u.Opaque == "" && u.Host != "" && !strings.HasSuffix(u.Host, ":") &&
+			// A parsed URL with no userinfo can still be a mis-read credential:
+			// url.Parse turns user:digits into host:port and a short username into
+			// the host, leaving the '@' in the path, query or fragment (issue #55).
+			// Returning unchanged is safe only when the input carries no raw '@' at
+			// all, or when the parsed host is a bracketed IPv6 literal whose tail
+			// holds no password span. '[' is an RFC 3986 gen-delim and invalid in
+			// userinfo, so a bracketed authority cannot itself be a credential.
+			(!strings.ContainsRune(host, '@') ||
+				(strings.HasPrefix(u.Host, "[") && !tailCarriesPassword(host))) {
 			return host
 		}
 	}
-	if u, err := url.Parse("//" + host); err == nil && u.User != nil {
-		return strings.TrimPrefix(u.Redacted(), "//")
+	// The scheme-less user:pass@host form parses as scheme:opaque, so reparse it as
+	// an authority. Only the single-'@' form is unambiguous enough to trust: with a
+	// second '@' the reparse invents an authority out of "scheme:user", masks the
+	// wrong span, and leaves the real password in place.
+	if strings.Count(host, "@") == 1 {
+		if u, err := url.Parse("//" + host); err == nil && u.User != nil {
+			return strings.TrimPrefix(u.Redacted(), "//")
+		}
 	}
 	return maskAuthorityPassword(host)
+}
+
+// redactedCoversCredential reports whether url.Redacted masks the whole credential
+// for a URL url.Parse decoded userinfo from. It does not in two cases, both of them
+// the authority split landing on the wrong '@' (issue #55): an email-style username
+// makes url.Parse read a password-less userinfo, and a second ':' before a later
+// '@' leaves a password span in the tail. Redacted only ever masks the password it
+// parsed, and never looks at the path, query or fragment.
+func redactedCoversCredential(u *url.URL, host string) bool {
+	if tailCarriesPassword(host) {
+		return false
+	}
+	if _, hasPassword := u.User.Password(); hasPassword {
+		return true
+	}
+	return strings.Count(host, "@") == 1
+}
+
+// authorityTail returns the path, query and fragment of host, i.e. everything after
+// the authority. It works on the raw string because the inputs that matter here are
+// exactly the ones url.Parse splits in the wrong place.
+func authorityTail(host string) string {
+	rest := host
+	if i := strings.Index(rest, "//"); i >= 0 && !strings.ContainsAny(rest[:i], "/?#@") {
+		rest = rest[i+2:]
+	}
+	if j := strings.IndexAny(rest, "/?#"); j >= 0 {
+		return rest[j:]
+	}
+	return ""
+}
+
+// tailCarriesPassword reports whether the tail holds a ':' before a later '@', the
+// shape of a password span url.Parse did not decode as userinfo.
+func tailCarriesPassword(host string) bool {
+	tail := authorityTail(host)
+	at := strings.LastIndexByte(tail, '@')
+	return at >= 0 && strings.IndexByte(tail[:at], ':') >= 0
 }
 
 // displayHost reduces a host URL to scheme://host[:port] for display in a tool

--- a/config.go
+++ b/config.go
@@ -240,10 +240,10 @@ func validateHostScheme(host string, allowHTTP bool) error {
 // userinfo without failing: an all-numeric password prefix parses as a port, a short
 // username parses as the host, and an email-style username makes the authority split
 // land on the wrong '@', each leaving the credential in the path, query or fragment
-// (issue #55). Any input those forms could describe falls through to be masked, so a
-// host is returned unchanged only when no reading of it places a password span in
-// the tail. Every host-URL log field and error message in this package routes
-// through it.
+// (issue #55). A host is returned unchanged only when no reading of it places a
+// password span in the tail. Masking is textual once url.Parse has mis-read the
+// input, so the masked host is the one the credential reading implies, which is not
+// always the authority the client actually dialled.
 //
 // Limitation: a password containing an unencoded "//" or "://" is indistinguishable
 // from URL scheme/authority structure (url.Parse reads it as a scheme and an opaque
@@ -282,11 +282,11 @@ func safeHost(host string) string {
 }
 
 // redactedCoversCredential reports whether url.Redacted masks the whole credential
-// for a URL url.Parse decoded userinfo from. It does not in two cases, both of them
-// the authority split landing on the wrong '@' (issue #55): an email-style username
-// makes url.Parse read a password-less userinfo, and a second ':' before a later
-// '@' leaves a password span in the tail. Redacted only ever masks the password it
-// parsed, and never looks at the path, query or fragment.
+// for a URL url.Parse decoded userinfo from. It does not when a ':' before a later
+// '@' leaves a password span in the tail, nor when the userinfo carries no password
+// and the host holds more than one '@', which means the authority split landed on
+// an '@' that was part of the username (issue #55). Redacted only ever masks the
+// password it parsed, and never looks at the path, query or fragment.
 func redactedCoversCredential(u *url.URL, host string) bool {
 	if tailCarriesPassword(host) {
 		return false
@@ -297,9 +297,10 @@ func redactedCoversCredential(u *url.URL, host string) bool {
 	return strings.Count(host, "@") == 1
 }
 
-// authorityTail returns the path, query and fragment of host, i.e. everything after
-// the authority. It works on the raw string because the inputs that matter here are
-// exactly the ones url.Parse splits in the wrong place.
+// authorityTail returns everything from the first '/', '?' or '#' that follows the
+// authority marker. That is not always url.Parse's own path/query/fragment split,
+// and deliberately so: the inputs that matter here are exactly the ones url.Parse
+// splits in the wrong place, so this works on the raw string instead.
 func authorityTail(host string) string {
 	rest := host
 	if i := strings.Index(rest, "//"); i >= 0 && !strings.ContainsAny(rest[:i], "/?#@") {

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strconv"
@@ -245,11 +246,12 @@ func validateHostScheme(host string, allowHTTP bool) error {
 // input, so the masked host is the one the credential reading implies, which is not
 // always the authority the client actually dialled.
 //
-// Limitation: a password containing an unencoded "//" or "://" is indistinguishable
-// from URL scheme/authority structure (url.Parse reads it as a scheme and an opaque
-// remainder, and the textual masker then treats the "//" as the authority marker),
-// so it may not be fully masked. RFC 3986 requires percent-encoding such characters
-// in userinfo; the realistic single-'/' base64 case is handled.
+// Limitation: a password that BEGINS with "://" behind a username that is itself a
+// valid URL scheme (as in "admin://secret@host") is not masked, because that is
+// byte-for-byte a scheme://authority URL whose userinfo is the username "secret"
+// with no password at all, and safeHost never masks a username. A "//" anywhere
+// else in the password, including the realistic base64 case, is handled. RFC 3986
+// requires percent-encoding these characters in userinfo.
 func safeHost(host string) string {
 	if u, err := url.Parse(host); err == nil {
 		if u.User != nil {
@@ -303,13 +305,49 @@ func redactedCoversCredential(u *url.URL, host string) bool {
 // splits in the wrong place, so this works on the raw string instead.
 func authorityTail(host string) string {
 	rest := host
-	if i := strings.Index(rest, "//"); i >= 0 && !strings.ContainsAny(rest[:i], "/?#@") {
-		rest = rest[i+2:]
+	if k := authorityMarker(rest); k >= 0 {
+		rest = rest[k:]
 	}
 	if j := strings.IndexAny(rest, "/?#"); j >= 0 {
 		return rest[j:]
 	}
 	return ""
+}
+
+// authorityMarker returns the index just past the "//" that introduces the
+// authority, or -1 when host has none. Only a leading "//" or one preceded by a
+// syntactically valid scheme counts. Accepting any "//" instead would let a
+// password containing one pose as the authority marker, which swallowed the real
+// password span and returned the host unmasked.
+func authorityMarker(host string) int {
+	const separator = "//"
+	i := strings.Index(host, separator)
+	switch {
+	case i < 0:
+		return -1
+	case i == 0:
+		return len(separator)
+	case host[i-1] == ':' && isURLScheme(host[:i-1]):
+		return i + len(separator)
+	default:
+		return -1
+	}
+}
+
+// isURLScheme reports whether s is a valid RFC 3986 scheme: ALPHA followed by any
+// of ALPHA, DIGIT, '+', '-' and '.'. The empty string is accepted so the malformed
+// but already-pinned "://host" form keeps its authority marker.
+func isURLScheme(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z':
+		case i > 0 && (c >= '0' && c <= '9' || c == '+' || c == '-' || c == '.'):
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // tailCarriesPassword reports whether the tail holds a ':' before a later '@', the
@@ -348,19 +386,43 @@ func displayHost(host string) string {
 // password span and is returned unchanged.
 func maskAuthorityPassword(host string) string {
 	rest, prefix := host, ""
-	// A leading "scheme://" or "//" precedes the authority; only treat "//" as the
-	// authority marker when nothing path-like or an '@' comes before it.
-	if i := strings.Index(rest, "//"); i >= 0 && !strings.ContainsAny(rest[:i], "/?#@") {
-		prefix, rest = rest[:i+2], rest[i+2:]
+	if k := authorityMarker(rest); k >= 0 {
+		prefix, rest = rest[:k], rest[k:]
 	}
 	at := strings.LastIndexByte(rest, '@')
 	if at < 0 {
 		return host // no userinfo
 	}
 	userinfo := rest[:at]
-	colon := strings.IndexByte(userinfo, ':')
+	colon := userinfoColon(userinfo)
 	if colon < 0 {
 		return host // no ':' before the delimiter, so there is no password span
 	}
 	return prefix + userinfo[:colon] + ":xxxxx" + rest[at:]
+}
+
+// userinfoColon returns the index of the ':' that starts the password span, or -1.
+// A leading bracketed IPv6 literal is skipped so its own colons are not mistaken
+// for the delimiter, which would otherwise mask from inside the address and leave
+// a truncated "[" where the host should be. The literal must parse as an IP, so a
+// bracket-prefixed username such as "[user:secret" still masks at its real colon.
+func userinfoColon(userinfo string) int {
+	from := 0
+	if strings.HasPrefix(userinfo, "[") {
+		if end := strings.IndexByte(userinfo, ']'); end > 0 {
+			literal := userinfo[1:end]
+			// A zone ID ("%25eth0" once percent-encoded) is not part of the address.
+			if pct := strings.IndexByte(literal, '%'); pct >= 0 {
+				literal = literal[:pct]
+			}
+			if net.ParseIP(literal) != nil {
+				from = end + 1
+			}
+		}
+	}
+	colon := strings.IndexByte(userinfo[from:], ':')
+	if colon < 0 {
+		return -1
+	}
+	return from + colon
 }

--- a/config.go
+++ b/config.go
@@ -203,11 +203,22 @@ func gatewayMode(cfg *Config) bool {
 // exposes them on the wire (CWE-319). https is always accepted; http only when the
 // operator opts in via CENTREON_ALLOW_HTTP. A missing or non-http(s) scheme, or an
 // unparseable URL, is rejected outright (fail closed). url.Parse normalises the
-// scheme to lowercase, so the cases below are matched in lowercase.
+// scheme to lowercase, so the cases below are matched in lowercase. A host that
+// still contains a raw '@' the parser did not consume as userinfo is also rejected:
+// it is a mis-encoded credential or a malformed base URL either way (issue #55).
 func validateHostScheme(host string, allowHTTP bool) error {
 	u, err := url.Parse(host)
 	if err != nil {
 		return fmt.Errorf("invalid host url %q: %w", safeHost(host), err)
+	}
+	// url.Parse can accept a mis-encoded credential without reporting userinfo: an
+	// all-numeric password prefix parses as a port and a short username as the host,
+	// leaving the '@' in the path, query or fragment (issue #55). A Centreon base URL
+	// never contains a raw '@', so reject the whole class rather than let the
+	// mis-parsed authority become a live client. Gated on http(s) so a scheme problem
+	// keeps its own more specific message.
+	if (u.Scheme == schemeHTTPS || u.Scheme == schemeHTTP) && u.User == nil && strings.ContainsRune(host, '@') {
+		return fmt.Errorf("host %q contains an unencoded '@' after the authority: percent-encode userinfo characters (RFC 3986) or remove the credential", safeHost(host))
 	}
 	switch u.Scheme {
 	case schemeHTTPS:
@@ -228,11 +239,15 @@ func validateHostScheme(host string, allowHTTP bool) error {
 // error message without leaking an embedded credential (CWE-532). It redacts the
 // standard scheme://user:pass@host form via url.Redacted and the scheme-less
 // user:pass@host form (which url.Parse treats as scheme:opaque, exposing no userinfo
-// to mask) by reparsing it as an authority. A password carrying an unescaped '/',
-// '?' or '#' breaks url.Parse; that form falls back to masking the password span
-// textually, so redaction fails closed. A credential-free host is returned
-// unchanged, so log greps on the hostname still match. Every host-URL log field and
-// validateHostScheme error message routes through it.
+// to mask) by reparsing it as an authority. url.Parse can also mis-read intended
+// userinfo without failing: an all-numeric password prefix parses as a port and a
+// short username parses as the host, leaving the credential in the path, query or
+// fragment (issue #55). An input that parses without userinfo but still carries a
+// raw '@' therefore falls through to be masked, except a parsed bracketed IPv6
+// authority, which can never be userinfo. A host with no '@' is returned unchanged,
+// and masking only ever replaces the span between the first ':' and the last '@',
+// so the hostname survives and log greps on it still match. Every host-URL log field
+// and validateHostScheme error message routes through it.
 //
 // Limitation: a password containing an unencoded "//" or "://" is indistinguishable
 // from URL scheme/authority structure (url.Parse reads it as a scheme and username),
@@ -243,12 +258,16 @@ func safeHost(host string) string {
 		if u.User != nil {
 			return u.Redacted()
 		}
-		// A well-formed hierarchical URL with a real host and no userinfo carries no
-		// credential: any ':' or '@' is in the host:port, path or query. A userinfo
-		// password that begins with '/' defeats that, because url.Parse mis-splits it
-		// into the path, leaving the host empty (scheme-less input) or ending in a
-		// bare ':' (scheme-present input); both fall through to be masked.
-		if u.Opaque == "" && u.Host != "" && !strings.HasSuffix(u.Host, ":") {
+		// A parsed URL with no userinfo can still be a mis-read credential: url.Parse
+		// turns user:digits into host:port and a short username into the host, leaving
+		// the '@' in the path, query or fragment (issue #55). Returning unchanged is
+		// only safe when the input carries no raw '@' at all, or when the parsed host
+		// is a bracketed IPv6 literal: '[' is an RFC 3986 gen-delim and invalid in
+		// userinfo, and an '@' inside a bracketed authority makes url.Parse fail with
+		// "invalid userinfo" rather than reach here. Anything else falls through to
+		// be masked.
+		if u.Opaque == "" && u.Host != "" && !strings.HasSuffix(u.Host, ":") &&
+			(!strings.ContainsRune(host, '@') || strings.HasPrefix(u.Host, "[")) {
 			return host
 		}
 	}
@@ -277,12 +296,13 @@ func displayHost(host string) string {
 	return redactedHostPlaceholder
 }
 
-// maskAuthorityPassword fails closed for host strings url.Parse cannot decode into
-// userinfo (a password with an unescaped '/', '?' or '#', a leading "://", or an
-// invalid percent-escape). It masks the password span from the first ':' to the
-// last '@' (the userinfo/host delimiter). A ':' sitting behind a path separator is
-// left alone, and a host with no userinfo is returned unchanged, so a legitimate
-// ':' or '@' in a path or query is never touched.
+// maskAuthorityPassword is the textual fail-closed fallback for host strings whose
+// userinfo url.Parse either rejects (a password with an unescaped '/', '?' or '#',
+// a leading "://", an invalid percent-escape) or silently mis-reads as host, port,
+// path, query or fragment (issue #55). It masks the span from the first ':' after
+// the authority marker to the last '@' (the userinfo/host delimiter). A string with
+// no '@', or with no ':' between the authority marker and the last '@', has no
+// password span and is returned unchanged.
 func maskAuthorityPassword(host string) string {
 	rest, prefix := host, ""
 	// A leading "scheme://" or "//" precedes the authority; only treat "//" as the
@@ -296,8 +316,8 @@ func maskAuthorityPassword(host string) string {
 	}
 	userinfo := rest[:at]
 	colon := strings.IndexByte(userinfo, ':')
-	if colon < 0 || strings.ContainsAny(userinfo[:colon], "/?#") {
-		return host // no password, or the ':' is in a path/query rather than userinfo
+	if colon < 0 {
+		return host // no ':' before the delimiter, so there is no password span
 	}
 	return prefix + userinfo[:colon] + ":xxxxx" + rest[at:]
 }

--- a/config_test.go
+++ b/config_test.go
@@ -268,6 +268,13 @@ func TestValidateHostScheme(t *testing.T) {
 		// parse-error branch, and notWant pins that the password stays out of it.
 		{"parse error keeps the password out of the message", "https://admin:se^kret@centreon.example.com", false, "invalid host url", "se^kret"},
 		{"parse error keeps a spaced password out of the message", "https://admin:se kret@centreon.example.com", false, "invalid host url", "se kret"},
+		// A raw '@' after the authority is NOT rejected. It is indistinguishable
+		// from a mis-encoded credential, so safeHost masks it, but rejecting the
+		// host would refuse legitimate base URLs carrying an '@' in a path or
+		// query. Redaction is the control here, not validation (issue #55).
+		{"accepts a credential-free host with @ in the path", "https://centreon.example.com:8080/a@b", false, "", ""},
+		{"accepts an @ in the path with no colon", "https://centreon.example.com/api@v1", false, "", ""},
+		{"accepts a mis-encoded credential, redaction is the control", "https://admin:1234/secret@centreon.example.com", false, "", ""},
 	}
 
 	for _, tt := range tests {
@@ -391,8 +398,8 @@ func TestSafeHost(t *testing.T) {
 // TestSafeHostNeverLeaksPassword sweeps a constructed grid of credential-shaped
 // hosts and asserts the invariant the row table can only sample: a marker placed in
 // password position never survives safeHost. Both issues in this area (#41 and #55)
-// turned up shapes the hand-written rows missed, and #55 alone covered three
-// families, so the class is pinned by a grid rather than by enumeration. A
+// turned up shapes the hand-written rows missed, so the class is pinned by varying
+// every placement that moves the authority split rather than by enumeration. A
 // constructed grid is used rather than go test -fuzz because it is deterministic,
 // needs no corpus in the repo, and runs in ordinary CI; a fuzz target could build
 // the same oracle from separate username and password arguments, so the oracle is

--- a/config_test.go
+++ b/config_test.go
@@ -262,14 +262,12 @@ func TestValidateHostScheme(t *testing.T) {
 		{"unsupported scheme rejected", "ftp://centreon.example.com", false, "unsupported scheme", ""},
 		{"host:port without scheme rejected as unsupported", "centreon.example.com:443", false, "unsupported scheme", ""},
 		{"unparseable host rejected", "127.0.0.1:8080", false, "invalid host url", ""},
-		// A raw '@' the parser did not consume as userinfo means the URL is either a
-		// mis-encoded credential or a malformed base URL; a Centreon base URL never
-		// contains one. Rejecting it stops the mis-parsed authority from becoming a
-		// live client, and the rejection message itself must stay redacted (#55).
-		{"rejects unencoded @ after authority", "https://admin:1234/secret@centreon.example.com", false, "unencoded '@'", "secret"},
-		{"rejects unencoded @ after portless authority", "https://us/er:secret@centreon.example.com", false, "unencoded '@'", "secret"},
-		{"rejects credential-free host with @ in path", "https://centreon.example.com:8080/a@b", false, "unencoded '@'", ""},
-		{"rejects unencoded @ over http with opt-in", "http://admin:1234/secret@centreon.example.com", true, "unencoded '@'", "secret"},
+		// url.Error.Error() reprints the URL it failed on, so wrapping it whole would
+		// undo the safeHost redaction in the very same message. These inputs fail
+		// url.Parse (an unescaped character in the password), so they exercise the
+		// parse-error branch, and notWant pins that the password stays out of it.
+		{"parse error keeps the password out of the message", "https://admin:se^kret@centreon.example.com", false, "invalid host url", "se^kret"},
+		{"parse error keeps a spaced password out of the message", "https://admin:se kret@centreon.example.com", false, "invalid host url", "se kret"},
 	}
 
 	for _, tt := range tests {
@@ -289,11 +287,12 @@ func TestValidateHostScheme(t *testing.T) {
 }
 
 // TestSafeHost pins that safeHost masks a userinfo password (so it cannot reach
-// logs or error messages, CWE-532) across every form that can carry one, including
-// the scheme-less user:pass@host form url.Redacted alone does not mask (issue #41)
-// and the forms url.Parse silently mis-reads as host, port, path, query or fragment
-// (issue #55). A host whose '@' cannot carry a password, and a bracketed IPv6
-// authority, are still returned byte for byte unchanged.
+// logs or error messages, CWE-532), including the scheme-less user:pass@host form
+// url.Redacted alone does not mask (issue #41) and the forms url.Parse silently
+// mis-reads as host, port, path, query or fragment (issue #55). A host whose '@'
+// cannot carry a password, and a bracketed IPv6 authority with no password span in
+// its tail, are still returned byte for byte unchanged. These rows are examples;
+// TestSafeHostNeverLeaksPassword sweeps the class.
 func TestSafeHost(t *testing.T) {
 	tests := []struct {
 		name string
@@ -345,6 +344,21 @@ func TestSafeHost(t *testing.T) {
 		// A username that merely starts with '[' is not a bracketed authority.
 		{"leaves IPv6 host with port and @ in path unchanged", "https://[2001:db8::1]:8443/x@y", "https://[2001:db8::1]:8443/x@y"},
 		{"masks username starting with a bracket", "https://[user:secret@centreon.example.com", "https://[user:xxxxx@centreon.example.com"},
+		// An email-style username makes url.Parse split the authority at the wrong
+		// '@', so it reports a password-less userinfo and url.Redacted has nothing to
+		// mask while the real password sits in the path, query or fragment (#55).
+		{"masks password behind an email-style username", "https://user@corp.com:1234/secret@centreon.example.com", "https://user@corp.com:xxxxx@centreon.example.com"},
+		{"masks password behind an email-style username in a query", "https://a@b:1234?secret@centreon.example.com", "https://a@b:xxxxx@centreon.example.com"},
+		{"masks password behind an email-style username in a fragment", "https://a@b:1234#secret@centreon.example.com", "https://a@b:xxxxx@centreon.example.com"},
+		// The opaque scheme:host form has no "//" authority marker, so the reparse
+		// fallback would invent one out of "https:user" and mask the wrong span.
+		{"masks opaque form with an email-style username", "https:user@corp.com:1234/secret@centreon.example.com", "https:xxxxx@centreon.example.com"},
+		// A bracketed IPv6 authority cannot be userinfo, but its tail still can, so
+		// the bracket exemption must not cover a password span after the authority.
+		{"masks a password span after a bracketed IPv6 authority", "https://[::1]/admin:secret@evil.example.com", "https://[:xxxxx@evil.example.com"},
+		// A real parsed password plus a second password span in the tail: Redacted
+		// masks only the first, so this must fall through to the textual masker.
+		{"masks a password span in the tail beside real userinfo", "https://admin:pw@centreon.example.com/x:secret@evil.example.com", "https://admin:xxxxx@evil.example.com"},
 		// Credential-free hosts must not be corrupted where that is decidable: a
 		// later '@' with no earlier ':' has no password span, and a bracketed IPv6
 		// authority can never be userinfo. A ':' followed by '@' after the authority
@@ -375,17 +389,39 @@ func TestSafeHost(t *testing.T) {
 }
 
 // TestSafeHostNeverLeaksPassword sweeps a constructed grid of credential-shaped
-// hosts and asserts the invariant the row table can only sample: a marker placed
-// in password position never survives safeHost. Three issues in a row (#41, #48,
-// #55) each turned up a shape the hand-written rows missed, so the class is pinned
-// by construction rather than by enumeration. A constructed grid is used instead of
-// go test -fuzz because random input has no oracle: nothing tells the fuzzer which
-// byte span was meant to be the password, whereas here the marker is known.
+// hosts and asserts the invariant the row table can only sample: a marker placed in
+// password position never survives safeHost. Both issues in this area (#41 and #55)
+// turned up shapes the hand-written rows missed, and #55 alone covered three
+// families, so the class is pinned by a grid rather than by enumeration. A
+// constructed grid is used rather than go test -fuzz because it is deterministic,
+// needs no corpus in the repo, and runs in ordinary CI; a fuzz target could build
+// the same oracle from separate username and password arguments, so the oracle is
+// not the reason.
 func TestSafeHostNeverLeaksPassword(t *testing.T) {
-	for _, host := range credentialHostGrid() {
-		if got := safeHost(host); strings.Contains(got, passwordMarker) {
-			t.Errorf("safeHost(%q) = %q, which leaks the password", host, got)
+	grid := credentialHostGrid()
+	// Without this the whole test passes vacuously if the builder ever returns
+	// nothing, which is the failure mode a pure absence assertion cannot see.
+	if len(grid) < 1000 {
+		t.Fatalf("credentialHostGrid() returned %d hosts, expected a full grid", len(grid))
+	}
+
+	failures := 0
+	for _, host := range grid {
+		// Positive control: the input must actually carry the marker, otherwise
+		// asserting its absence from the output proves nothing.
+		if !strings.Contains(host, passwordMarker) {
+			t.Fatalf("grid host %q does not contain the marker, the builder is wrong", host)
 		}
+		if got := safeHost(host); strings.Contains(got, passwordMarker) {
+			failures++
+			// Cap the output: a regression here leaks thousands of rows at once.
+			if failures <= 20 {
+				t.Errorf("safeHost(%q) = %q, which leaks the password", host, got)
+			}
+		}
+	}
+	if failures > 20 {
+		t.Errorf("safeHost leaked the password in %d of %d grid hosts", failures, len(grid))
 	}
 }
 
@@ -395,27 +431,34 @@ const passwordMarker = "SEKRIT"
 
 // credentialHostGrid builds credential-shaped host URLs by combining a scheme, a
 // username, a password holding passwordMarker, a host and a trailing path, query or
-// fragment. It covers the delimiter placements url.Parse mis-reads: an unencoded
-// '/', '?' or '#' in either the username or the password, and an all-numeric
-// password prefix that parses as a port (issue #55).
+// fragment. It covers the placements url.Parse mis-reads: an unencoded '/', '?' or
+// '#' in either the username or the password, an all-numeric password prefix that
+// parses as a port, an email-style username that moves the authority split onto the
+// wrong '@', and a second password span in the tail (issue #55).
 func credentialHostGrid() []string {
-	schemes := []string{"https://", "http://", "//", "://", ""}
-	usernames := []string{"admin", "us/er", "us?er", "us#er", "us.er", "[user", "us[er"}
+	schemes := []string{"https://", "http://", "//", "://", "", "https:"}
+	usernames := []string{
+		"admin", "us/er", "us?er", "us#er", "us.er", "[user", "us[er",
+		"user@corp.com", "a@b",
+	}
+	// No password here contains "//": that form is indistinguishable from URL
+	// scheme/authority structure and safeHost documents it as unmaskable, so the
+	// grid would assert a limitation rather than the fix.
 	passwords := []string{
 		passwordMarker, "1234/" + passwordMarker, "1234?" + passwordMarker,
 		"1234#" + passwordMarker, "/" + passwordMarker, "?" + passwordMarker,
 		"#" + passwordMarker, "aB9/" + passwordMarker, passwordMarker + "/tail",
-		"1234/sec:" + passwordMarker,
+		"1234/sec:" + passwordMarker, "pw/" + passwordMarker, "p@" + passwordMarker,
 	}
-	hosts := []string{"centreon.example.com", "centreon.example.com:8443", "[2001:db8::1]:8443"}
-	tails := []string{"", "/mon", "?q=1", "#f"}
+	hosts := []string{
+		"centreon.example.com", "centreon.example.com:8443",
+		"[2001:db8::1]:8443", "[::1]",
+	}
+	tails := []string{"", "/mon", "?q=1", "#f", "/a@b", "/d:" + passwordMarker + "@f"}
 
 	userinfos := make([]string, 0, len(usernames)*len(passwords))
 	for _, username := range usernames {
 		for _, password := range passwords {
-			if skipKnownFailOpen(username, password) {
-				continue
-			}
 			userinfos = append(userinfos, username+":"+password)
 		}
 	}
@@ -436,17 +479,6 @@ func credentialHostGrid() []string {
 		}
 	}
 	return grid
-}
-
-// skipKnownFailOpen excludes the two shape families safeHost documents as
-// unmaskable, so the sweep pins the fix without also asserting a behaviour the
-// helper never claimed. A password containing "//" is indistinguishable from URL
-// scheme/authority structure. A username starting with '[' combined with a ']' in
-// the password collides with a bracketed IPv6 authority; both brackets are RFC 3986
-// gen-delims and invalid in userinfo, so the authority reading wins.
-func skipKnownFailOpen(username, password string) bool {
-	return strings.Contains(password, "//") ||
-		(strings.HasPrefix(username, "[") && strings.Contains(password, "]"))
 }
 
 // TestDisplayHost pins that displayHost reduces a host URL to scheme://host[:port]

--- a/config_test.go
+++ b/config_test.go
@@ -262,6 +262,14 @@ func TestValidateHostScheme(t *testing.T) {
 		{"unsupported scheme rejected", "ftp://centreon.example.com", false, "unsupported scheme", ""},
 		{"host:port without scheme rejected as unsupported", "centreon.example.com:443", false, "unsupported scheme", ""},
 		{"unparseable host rejected", "127.0.0.1:8080", false, "invalid host url", ""},
+		// A raw '@' the parser did not consume as userinfo means the URL is either a
+		// mis-encoded credential or a malformed base URL; a Centreon base URL never
+		// contains one. Rejecting it stops the mis-parsed authority from becoming a
+		// live client, and the rejection message itself must stay redacted (#55).
+		{"rejects unencoded @ after authority", "https://admin:1234/secret@centreon.example.com", false, "unencoded '@'", "secret"},
+		{"rejects unencoded @ after portless authority", "https://us/er:secret@centreon.example.com", false, "unencoded '@'", "secret"},
+		{"rejects credential-free host with @ in path", "https://centreon.example.com:8080/a@b", false, "unencoded '@'", ""},
+		{"rejects unencoded @ over http with opt-in", "http://admin:1234/secret@centreon.example.com", true, "unencoded '@'", "secret"},
 	}
 
 	for _, tt := range tests {
@@ -282,8 +290,10 @@ func TestValidateHostScheme(t *testing.T) {
 
 // TestSafeHost pins that safeHost masks a userinfo password (so it cannot reach
 // logs or error messages, CWE-532) across every form that can carry one, including
-// the scheme-less user:pass@host form url.Redacted alone does not mask (issue #41),
-// while leaving a credential-free host byte for byte unchanged.
+// the scheme-less user:pass@host form url.Redacted alone does not mask (issue #41)
+// and the forms url.Parse silently mis-reads as host, port, path, query or fragment
+// (issue #55). A host whose '@' cannot carry a password, and a bracketed IPv6
+// authority, are still returned byte for byte unchanged.
 func TestSafeHost(t *testing.T) {
 	tests := []struct {
 		name string
@@ -312,10 +322,40 @@ func TestSafeHost(t *testing.T) {
 		{"masks password beginning with a slash", "https://admin:/sekret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
 		{"masks scheme-less password beginning with a slash", "admin:/sekret@centreon.example.com", "admin:xxxxx@centreon.example.com"},
 		{"masks scheme-less password beginning with a question mark", "admin:?sekret@centreon.example.com", "admin:xxxxx@centreon.example.com"},
-		// Credential-free hosts whose path or query legitimately contains ':' or '@'
-		// must never be corrupted.
-		{"leaves host:port with @ in path unchanged", "https://centreon.example.com:8080/a@b", "https://centreon.example.com:8080/a@b"},
-		{"leaves : and @ in query unchanged", "https://centreon.example.com:8443/x?a=b:c@d", "https://centreon.example.com:8443/x?a=b:c@d"},
+		// url.Parse can mis-read intended userinfo without failing: an all-numeric
+		// password prefix parses as a port, so admin:1234 becomes host:port and the
+		// password tail lands in the path, query or fragment (issue #55).
+		{"masks numeric-prefix password with a slash", "https://admin:1234/secret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		{"masks numeric-prefix password with a question mark", "https://admin:1234?secret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		{"masks numeric-prefix password with a hash", "https://admin:1234#secret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		{"masks numeric-prefix password ahead of a real host:port", "https://admin:1234/secret@centreon.example.com:8443/mon", "https://admin:xxxxx@centreon.example.com:8443/mon"},
+		{"masks protocol-relative numeric-prefix password", "//admin:1234/secret@centreon.example.com", "//admin:xxxxx@centreon.example.com"},
+		// The same mis-read happens from the username side: an unencoded '/', '?' or
+		// '#' in the username makes url.Parse take the leading span as the host and
+		// leave the whole credential in the path, query or fragment (issue #55).
+		{"masks password behind a username with a slash", "https://us/er:secret@centreon.example.com", "https://us/er:xxxxx@centreon.example.com"},
+		{"masks password behind a username with a question mark", "https://us?er:secret@centreon.example.com", "https://us?er:xxxxx@centreon.example.com"},
+		{"masks password behind a username with a hash", "https://us#er:secret@centreon.example.com", "https://us#er:xxxxx@centreon.example.com"},
+		// A ':' before a later raw '@' always admits a credential reading, so it is
+		// masked whether or not url.Parse decoded the URL (issue #55).
+		{"masks ambiguous colon and @ after a portless authority", "https://centreon.example.com/a:b@c", "https://centreon.example.com/a:xxxxx@c"},
+		{"masks ambiguous colon and @ in an unparseable URL", "https://host/%zz/a:b@c", "https://host/%zz/a:xxxxx@c"},
+		// A bracketed authority is a genuine IPv6 literal: '[' is an RFC 3986
+		// gen-delim and invalid in userinfo, so it cannot be a mis-read credential.
+		// A username that merely starts with '[' is not a bracketed authority.
+		{"leaves IPv6 host with port and @ in path unchanged", "https://[2001:db8::1]:8443/x@y", "https://[2001:db8::1]:8443/x@y"},
+		{"masks username starting with a bracket", "https://[user:secret@centreon.example.com", "https://[user:xxxxx@centreon.example.com"},
+		// Credential-free hosts must not be corrupted where that is decidable: a
+		// later '@' with no earlier ':' has no password span, and a bracketed IPv6
+		// authority can never be userinfo. A ':' followed by '@' after the authority
+		// is genuinely ambiguous and fails closed instead (issue #55).
+		//
+		// These two rows changed with #55. "https://centreon.example.com:8080/a@b" is
+		// byte-for-byte indistinguishable from user "centreon.example.com", password
+		// "8080/a", host "b", so redaction fails closed; the text before the first
+		// ':' survives, so hostname greps still match.
+		{"masks ambiguous host:port with @ in path", "https://centreon.example.com:8080/a@b", "https://centreon.example.com:xxxxx@b"},
+		{"masks ambiguous : and @ in query", "https://centreon.example.com:8443/x?a=b:c@d", "https://centreon.example.com:xxxxx@d"},
 		{"leaves IPv6 host with @ in path unchanged", "https://[2001:db8::1]/x@y", "https://[2001:db8::1]/x@y"},
 		{"leaves scheme-less host with @ in path unchanged", "centreon.example.com/a@b", "centreon.example.com/a@b"},
 		{"leaves plain host unchanged", "https://centreon.example.com", "https://centreon.example.com"},
@@ -332,6 +372,81 @@ func TestSafeHost(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSafeHostNeverLeaksPassword sweeps a constructed grid of credential-shaped
+// hosts and asserts the invariant the row table can only sample: a marker placed
+// in password position never survives safeHost. Three issues in a row (#41, #48,
+// #55) each turned up a shape the hand-written rows missed, so the class is pinned
+// by construction rather than by enumeration. A constructed grid is used instead of
+// go test -fuzz because random input has no oracle: nothing tells the fuzzer which
+// byte span was meant to be the password, whereas here the marker is known.
+func TestSafeHostNeverLeaksPassword(t *testing.T) {
+	for _, host := range credentialHostGrid() {
+		if got := safeHost(host); strings.Contains(got, passwordMarker) {
+			t.Errorf("safeHost(%q) = %q, which leaks the password", host, got)
+		}
+	}
+}
+
+// passwordMarker appears only in password position in the credentialHostGrid
+// inputs, so finding it in safeHost output is unambiguously a leak.
+const passwordMarker = "SEKRIT"
+
+// credentialHostGrid builds credential-shaped host URLs by combining a scheme, a
+// username, a password holding passwordMarker, a host and a trailing path, query or
+// fragment. It covers the delimiter placements url.Parse mis-reads: an unencoded
+// '/', '?' or '#' in either the username or the password, and an all-numeric
+// password prefix that parses as a port (issue #55).
+func credentialHostGrid() []string {
+	schemes := []string{"https://", "http://", "//", "://", ""}
+	usernames := []string{"admin", "us/er", "us?er", "us#er", "us.er", "[user", "us[er"}
+	passwords := []string{
+		passwordMarker, "1234/" + passwordMarker, "1234?" + passwordMarker,
+		"1234#" + passwordMarker, "/" + passwordMarker, "?" + passwordMarker,
+		"#" + passwordMarker, "aB9/" + passwordMarker, passwordMarker + "/tail",
+		"1234/sec:" + passwordMarker,
+	}
+	hosts := []string{"centreon.example.com", "centreon.example.com:8443", "[2001:db8::1]:8443"}
+	tails := []string{"", "/mon", "?q=1", "#f"}
+
+	userinfos := make([]string, 0, len(usernames)*len(passwords))
+	for _, username := range usernames {
+		for _, password := range passwords {
+			if skipKnownFailOpen(username, password) {
+				continue
+			}
+			userinfos = append(userinfos, username+":"+password)
+		}
+	}
+
+	targets := make([]string, 0, len(hosts)*len(tails))
+	for _, host := range hosts {
+		for _, tail := range tails {
+			targets = append(targets, host+tail)
+		}
+	}
+
+	grid := make([]string, 0, len(schemes)*len(userinfos)*len(targets))
+	for _, scheme := range schemes {
+		for _, userinfo := range userinfos {
+			for _, target := range targets {
+				grid = append(grid, scheme+userinfo+"@"+target)
+			}
+		}
+	}
+	return grid
+}
+
+// skipKnownFailOpen excludes the two shape families safeHost documents as
+// unmaskable, so the sweep pins the fix without also asserting a behaviour the
+// helper never claimed. A password containing "//" is indistinguishable from URL
+// scheme/authority structure. A username starting with '[' combined with a ']' in
+// the password collides with a bracketed IPv6 authority; both brackets are RFC 3986
+// gen-delims and invalid in userinfo, so the authority reading wins.
+func skipKnownFailOpen(username, password string) bool {
+	return strings.Contains(password, "//") ||
+		(strings.HasPrefix(username, "[") && strings.Contains(password, "]"))
 }
 
 // TestDisplayHost pins that displayHost reduces a host URL to scheme://host[:port]

--- a/config_test.go
+++ b/config_test.go
@@ -362,10 +362,23 @@ func TestSafeHost(t *testing.T) {
 		{"masks opaque form with an email-style username", "https:user@corp.com:1234/secret@centreon.example.com", "https:xxxxx@centreon.example.com"},
 		// A bracketed IPv6 authority cannot be userinfo, but its tail still can, so
 		// the bracket exemption must not cover a password span after the authority.
-		{"masks a password span after a bracketed IPv6 authority", "https://[::1]/admin:secret@evil.example.com", "https://[:xxxxx@evil.example.com"},
+		// The address' own colons must not be taken for the password delimiter
+		// either, or the host collapses to "[" and the log line loses its target.
+		{"masks a password span after a bracketed IPv6 authority", "https://[::1]/admin:secret@evil.example.com", "https://[::1]/admin:xxxxx@evil.example.com"},
+		{"keeps a bracketed IPv6 host and port while masking the tail", "https://[2001:db8::1]:8443?owner:secret@evil.example.com", "https://[2001:db8::1]:xxxxx@evil.example.com"},
+		{"keeps an IPv6 zone ID while masking the tail", "https://[fe80::1%25eth0]:8443/mon?u=a:secret@c", "https://[fe80::1%25eth0]:xxxxx@c"},
+		// A bracket-prefixed username is not an IPv6 literal, so its first ':' is
+		// still the delimiter.
+		{"masks a bracket-prefixed username that is not an IP", "https://[notanip:secret]x@centreon.example.com", "https://[notanip:xxxxx@centreon.example.com"},
 		// A real parsed password plus a second password span in the tail: Redacted
 		// masks only the first, so this must fall through to the textual masker.
 		{"masks a password span in the tail beside real userinfo", "https://admin:pw@centreon.example.com/x:secret@evil.example.com", "https://admin:xxxxx@evil.example.com"},
+		// A "//" inside the password used to pose as the authority marker, so the
+		// textual masker treated the real password as the authority and returned the
+		// host unmasked. Only a leading "//" or one behind a valid scheme counts now.
+		{"masks a scheme-less password containing //", "admin:pw//secret@centreon.example.com", "admin:xxxxx@centreon.example.com"},
+		{"masks a scheme-less password containing ://", "admin:pw://secret@centreon.example.com", "admin:xxxxx@centreon.example.com"},
+		{"masks a base64-style password containing //", "admin:aB9//xY2z@centreon.example.com", "admin:xxxxx@centreon.example.com"},
 		// Credential-free hosts must not be corrupted where that is decidable: a
 		// later '@' with no earlier ':' has no password span, and a bracketed IPv6
 		// authority can never be userinfo. A ':' followed by '@' after the authority
@@ -448,14 +461,17 @@ func credentialHostGrid() []string {
 		"admin", "us/er", "us?er", "us#er", "us.er", "[user", "us[er",
 		"user@corp.com", "a@b",
 	}
-	// No password here contains "//": that form is indistinguishable from URL
-	// scheme/authority structure and safeHost documents it as unmaskable, so the
-	// grid would assert a limitation rather than the fix.
+	// A password BEGINNING with "://" is deliberately absent: behind a scheme-shaped
+	// username that is byte-for-byte a scheme://authority URL whose userinfo holds a
+	// username and no password, which safeHost never masks. safeHost documents it.
+	// Every other "//" placement is covered, including mid-password, which is the
+	// realistic base64 case.
 	passwords := []string{
 		passwordMarker, "1234/" + passwordMarker, "1234?" + passwordMarker,
 		"1234#" + passwordMarker, "/" + passwordMarker, "?" + passwordMarker,
 		"#" + passwordMarker, "aB9/" + passwordMarker, passwordMarker + "/tail",
 		"1234/sec:" + passwordMarker, "pw/" + passwordMarker, "p@" + passwordMarker,
+		"pw//" + passwordMarker, "pw://" + passwordMarker, "aB9//" + passwordMarker,
 	}
 	hosts := []string{
 		"centreon.example.com", "centreon.example.com:8443",

--- a/server_test.go
+++ b/server_test.go
@@ -139,6 +139,9 @@ func TestGatewayServer_RedactsUserinfoInHostLogs(t *testing.T) {
 		// the one place an attacker supplies the header.
 		{"numeric-prefix password not in allowlist", allowlist, newReq("https://gwuser:1234/"+secret+"@evil.example.com", true), "gwuser:xxxxx@"},
 		{"email-style username not in allowlist", allowlist, newReq("https://gwuser@corp.com:1234/"+secret+"@evil.example.com", true), "gwuser@corp.com:xxxxx@"},
+		// A "//" inside the password posed as the authority marker, so the textual
+		// masker returned this host unmasked straight into the log.
+		{"password containing // not in allowlist", allowlist, newReq("gwuser:pw//"+secret+"@evil.example.com", true), "gwuser:xxxxx@"},
 		// empty allowlist + no credential headers -> missing-credentials path.
 		{"missing credentials", &Config{}, newReq("https://gwuser:"+secret+"@evil.example.com", false), "gwuser:xxxxx@"},
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -123,14 +123,24 @@ func TestGatewayServer_RedactsUserinfoInHostLogs(t *testing.T) {
 		name string
 		cfg  *Config
 		req  *http.Request
+		// wantMask is the redacted userinfo the log line must show. It varies by
+		// row because url.Parse splits the authority at a different '@' depending
+		// on the shape, so a single literal cannot cover them all.
+		wantMask string
 	}{
 		// The host-not-in-allowlist path logs before validateHostScheme, so it sees
 		// the raw header for both the standard and the scheme-less credential form
 		// (the scheme-less form is the one url.Redacted alone would miss, issue #41).
-		{"scheme-ful host not in allowlist", allowlist, newReq("https://gwuser:"+secret+"@evil.example.com", true)},
-		{"scheme-less host not in allowlist", allowlist, newReq("gwuser:"+secret+"@evil.example.com", true)},
+		{"scheme-ful host not in allowlist", allowlist, newReq("https://gwuser:"+secret+"@evil.example.com", true), "gwuser:xxxxx@"},
+		{"scheme-less host not in allowlist", allowlist, newReq("gwuser:"+secret+"@evil.example.com", true), "gwuser:xxxxx@"},
+		// Issue #55: url.Parse mis-reads these as host:port or as a password-less
+		// userinfo, so url.Redacted masks nothing. This log runs before
+		// validateHostScheme, so safeHost is the only control on this sink and it is
+		// the one place an attacker supplies the header.
+		{"numeric-prefix password not in allowlist", allowlist, newReq("https://gwuser:1234/"+secret+"@evil.example.com", true), "gwuser:xxxxx@"},
+		{"email-style username not in allowlist", allowlist, newReq("https://gwuser@corp.com:1234/"+secret+"@evil.example.com", true), "gwuser@corp.com:xxxxx@"},
 		// empty allowlist + no credential headers -> missing-credentials path.
-		{"missing credentials", &Config{}, newReq("https://gwuser:"+secret+"@evil.example.com", false)},
+		{"missing credentials", &Config{}, newReq("https://gwuser:"+secret+"@evil.example.com", false), "gwuser:xxxxx@"},
 	}
 
 	for _, tt := range tests {
@@ -151,8 +161,8 @@ func TestGatewayServer_RedactsUserinfoInHostLogs(t *testing.T) {
 			if strings.Contains(out, secret) {
 				t.Errorf("log leaked embedded password (CWE-532): %s", out)
 			}
-			if !strings.Contains(out, "gwuser:xxxxx@") {
-				t.Errorf("expected redacted host (url.Redacted) in log, got: %s", out)
+			if !strings.Contains(out, tt.wantMask) {
+				t.Errorf("expected redacted host containing %q in log, got: %s", tt.wantMask, out)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #55.

`safeHost` masks an embedded userinfo password so a host URL can reach a log field without recording a credential (CWE-532). It failed open for a family of shapes where `url.Parse` mis-reads the intended userinfo without reporting an error.

## What leaked

Issue #55 reported three shapes: an all-numeric password prefix parses as a port, so `https://admin:1234/secret@host` came back byte for byte. Review found three more families the issue did not cover, each with the same root cause and each reachable the same way:

- an unencoded `/`, `?` or `#` in the **username** (`https://us/er:secret@host`), which also defeated the textual masker, because its guard treated a delimiter before the colon as proof the `:` belonged to a path
- an **email-style username** (`https://user@corp.com:1234/secret@host`), which moves the authority split onto the wrong `@`, so `url.Parse` reports a password-less userinfo, `url.Redacted` has nothing to mask, and the real password sits in the path. This one short-circuited above the guard that fixed the first family, so the initial fix did not close it
- the **opaque** `scheme:host` form, where the scheme-less reparse fallback invented an authority out of `scheme:user` and masked the wrong span

Reachability is the gateway allowlist log at `server.go:373`, which runs **before** `validateHostScheme` and writes an attacker-supplied `X-Centreon-Host` through `safeHost`. That ordering is why redaction, not validation, is the load-bearing control here.

## The fix

`url.Redacted` is used only where it demonstrably covers the credential. Anything whose tail could hold a password span falls through to the textual masker. The bracketed-IPv6 carve-out still exists (a `[` is an RFC 3986 gen-delim and cannot appear in userinfo) but now also requires an unambiguous tail, and the reparse fallback is limited to the single-`@` form it was written for.

A `:` followed by a later `@` is genuinely ambiguous: `https://host:8080/a@b` is byte-for-byte identical to user `host`, password `8080/a`, host `b`, and no parser can separate the readings. Redaction fails closed there, so two previously pinned rows change from unchanged to masked. The cost is legibility in a log line; the alternative is a credential in it.

Also fixed, pre-existing and in the same function: the parse-error branch wrapped the `*url.Error` whole, and `url.Error.Error()` reprints the URL it failed on, so the raw password reappeared in the very message `safeHost` had just redacted. Only the reason is wrapped now.

## What I deliberately did not do

An earlier revision of this branch also made `validateHostScheme` reject any http(s) host carrying a raw `@`. It is reverted. It was scope beyond #55, it refused legitimate base URLs such as `https://centreon.example.com/api@v1`, it contradicted `safeHost` by rejecting bracketed IPv6 hosts the sibling helper proves cannot be credentials, and two attempts to state its predicate correctly both mis-classified real inputs. Three test rows now pin that this class is accepted, so the decision is recorded rather than implied. Redaction covers the hazard on its own.

## Evidence

Measured over a 264,960 input grid built by a reviewer on axes independent of the ones used to develop the fix, with a marker placed only in password position:

| revision | leaking inputs |
|---|---|
| `main` | 16,800 |
| first commit on this branch | 8,640 |
| this branch | **0** |

No input leaks here that did not leak before. Every new guard was sabotaged individually and turns tests red; the committed grid sweep grew from 4,200 to 15,552 cases and now varies the placements that actually leaked, with a non-empty guard and a per-input positive control, because an earlier version of it would have passed on an empty grid.

## Follow-ups filed

- #57 `displayHost` echoes a mis-parsed authority to clients (out of scope here, belongs in `displayHost`)
- #58 `validateHostScheme` accepts a hostless URL, after which the client echoes the raw credential
- #59 batched low-severity findings
- tphakala/centreon-go-client#42 the client logs the full base URL including userinfo, which bypasses this repo's redaction entirely. Worth knowing that #55 is not fully mitigated end to end until that ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when connecting to invalid or malformed host URLs.
  - Prevented passwords and other credentials from appearing in host validation errors and server logs.
  - Strengthened credential masking for ambiguous, malformed, IPv6, and email-style host formats.

- **Tests**
  - Added comprehensive coverage to verify credentials are consistently redacted across varied URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->