### PR TITLE
fix: mask two credential families safeHost still leaked into logs (#62)

### DIFF
--- a/config.go
+++ b/config.go
@@ -283,21 +283,28 @@ func safeHost(host string) string {
 			// A parsed URL with no userinfo can still be a mis-read credential:
 			// url.Parse turns user:digits into host:port and a short username into
 			// the host, leaving the '@' in the path, query or fragment (issue #55).
-			// Returning unchanged is safe only when the input carries no raw '@' at
-			// all, or when the parsed host is a bracketed IPv6 literal whose tail
-			// holds no password span. '[' is an RFC 3986 gen-delim and invalid in
-			// userinfo, so a bracketed authority cannot itself be a credential.
-			(!strings.ContainsRune(host, '@') ||
+			// Returning unchanged is safe only when the input carries no at sign that
+			// could be a userinfo delimiter, raw OR percent-encoded as %40, which
+			// tailCarriesAtSign decodes (issue #62); or when the parsed host is a
+			// bracketed IPv6 literal whose tail holds no password span. '[' is an RFC
+			// 3986 gen-delim and invalid in userinfo, so a bracketed authority cannot
+			// itself be a credential. afterAuthorityDelimiter (not authorityTail) is
+			// used so an encoded '@' sitting in the authority of a host:port form, with
+			// no '/', '?' or '#' after it, is still seen.
+			((!strings.ContainsRune(host, '@') && !tailCarriesAtSign(afterAuthorityDelimiter(host))) ||
 				(strings.HasPrefix(u.Host, "[") && !tailCarriesPassword(host))) {
 			return host
 		}
 	}
 	// The scheme-less user:pass@host form parses as scheme:opaque, so reparse it as
-	// an authority. Only the single-'@' form is unambiguous enough to trust: with a
-	// second '@' the reparse invents an authority out of "scheme:user", masks the
-	// wrong span, and leaves the real password in place.
+	// an authority. Only the single-'@' form with no further at sign after the
+	// delimiter is unambiguous enough to trust: a second '@' (raw, or percent-encoded
+	// as %40 in the tail) means the reparse would invent an authority out of
+	// "scheme:user" or mask the wrong span and leave the real password in place, so
+	// those fall through to the textual masker instead (issues #55, #62).
 	if strings.Count(host, "@") == 1 {
-		if u, err := url.Parse("//" + host); err == nil && u.User != nil {
+		if u, err := url.Parse("//" + host); err == nil && u.User != nil &&
+			!tailCarriesAtSign(afterAuthorityDelimiter(host)) {
 			return strings.TrimPrefix(u.Redacted(), "//")
 		}
 	}
@@ -305,13 +312,15 @@ func safeHost(host string) string {
 }
 
 // redactedCoversCredential reports whether url.Redacted masks the whole credential
-// for a URL url.Parse decoded userinfo from. It does not when a ':' before a later
-// '@' leaves a password span in the tail, nor when the userinfo carries no password
-// and the host holds more than one '@', which means the authority split landed on
-// an '@' that was part of the username (issue #55). Redacted only ever masks the
-// password it parsed, and never looks at the path, query or fragment.
+// for a URL url.Parse decoded userinfo from. It does not when an at sign, raw or
+// percent-encoded as %40, survives after the '@' url.Parse split the authority at:
+// the split may then have landed inside the password and left the rest in the host,
+// path, query or fragment (issues #55, #62). It also does not when the userinfo
+// carries no password and the host holds more than one '@', which means the split
+// landed on an '@' that was part of the username. Redacted only ever masks the
+// password it parsed, and never looks past the authority it chose.
 func redactedCoversCredential(u *url.URL, host string) bool {
-	if tailCarriesPassword(host) {
+	if tailCarriesAtSign(afterAuthorityDelimiter(host)) {
 		return false
 	}
 	if _, hasPassword := u.User.Password(); hasPassword {
@@ -333,6 +342,30 @@ func authorityTail(host string) string {
 		return rest[j:]
 	}
 	return ""
+}
+
+// afterAuthorityDelimiter returns the span of host that follows the '@' url.Parse
+// takes as the userinfo/host delimiter: the last raw '@' inside the authority (the
+// text between the "//" marker and the first '/', '?' or '#'). It differs from
+// authorityTail, which starts at that first '/', '?' or '#' and so cannot see the
+// host remnant a mis-read leaves before it ("cret" in "admin:se@cret/path@host").
+// With no raw '@' in the authority it returns the whole post-marker span, so an
+// encoded delimiter further along is still in view. This reproduces Parse's own
+// split point textually, which is what lets safeHost tell a decoded password that
+// Redacted fully covers from one it only partly covers (issue #62).
+func afterAuthorityDelimiter(host string) string {
+	rest := host
+	if k := authorityMarker(rest); k >= 0 {
+		rest = rest[k:]
+	}
+	auth := rest
+	if j := strings.IndexAny(rest, "/?#"); j >= 0 {
+		auth = rest[:j]
+	}
+	if at := strings.LastIndexByte(auth, '@'); at >= 0 {
+		return rest[at+1:]
+	}
+	return rest
 }
 
 // authorityMarker returns the index just past the "//" that introduces the
@@ -372,10 +405,13 @@ func isURLScheme(s string) bool {
 }
 
 // tailCarriesPassword reports whether the tail holds a ':' before a later '@', the
-// shape of a password span url.Parse did not decode as userinfo.
+// shape of a password span url.Parse did not decode as userinfo. The '@' may be
+// percent-encoded (%40), so the delimiter is located with lastAtDelimiter rather
+// than a raw-byte search; this closes the same hole in a bracketed-IPv6 tail that
+// the encoded-delimiter fix closes elsewhere (issue #62).
 func tailCarriesPassword(host string) bool {
 	tail := authorityTail(host)
-	at := strings.LastIndexByte(tail, '@')
+	at := lastAtDelimiter(tail)
 	return at >= 0 && strings.IndexByte(tail[:at], ':') >= 0
 }
 
@@ -466,15 +502,17 @@ func tailCarriesAtSign(tail string) bool {
 // userinfo url.Parse either rejects (a password with an unescaped '/', '?' or '#',
 // a leading "://", an invalid percent-escape) or silently mis-reads as host, port,
 // path, query or fragment (issue #55). It masks the span from the first ':' after
-// the authority marker to the last '@' (the userinfo/host delimiter). A string with
-// no '@', or with no ':' between the authority marker and the last '@', has no
-// password span and is returned unchanged.
+// the authority marker to the delimiter '@', found by lastAtDelimiter so a
+// percent-encoded delimiter (%40) is located too (issue #62). A string with no
+// delimiter, or with no ':' before it, has no password span and is returned
+// unchanged. The encoded delimiter is kept verbatim in the output, so the host
+// after it still greps.
 func maskAuthorityPassword(host string) string {
 	rest, prefix := host, ""
 	if k := authorityMarker(rest); k >= 0 {
 		prefix, rest = rest[:k], rest[k:]
 	}
-	at := strings.LastIndexByte(rest, '@')
+	at := lastAtDelimiter(rest)
 	if at < 0 {
 		return host // no userinfo
 	}
@@ -503,6 +541,16 @@ func userinfoColon(userinfo string) int {
 			if net.ParseIP(literal) != nil {
 				from = end + 1
 			}
+		} else if net.ParseIP(userinfo[1:]) != nil {
+			// No closing ']': the delimiter the caller found sits inside the bracket
+			// because url.Parse rejected the authority (an invalid '%40' zone lands
+			// here, issue #62) and the ']' fell past it. Only when the ENTIRE span
+			// after '[' is a valid IP is it the host literal with no password to mask,
+			// so return -1. net.ParseIP rejects a zone or a ':' after the address, so a
+			// span like "[192.168.0.1%x:secret" is NOT taken as bare host: it falls
+			// through and its ':secret' is masked below. (Stripping at '%' first would
+			// misread that as a zoned address and leak the password.)
+			return -1
 		}
 	}
 	colon := strings.IndexByte(userinfo[from:], ':')
@@ -510,4 +558,43 @@ func userinfoColon(userinfo string) int {
 		return -1
 	}
 	return from + colon
+}
+
+// lastAtDelimiter returns the index in s of the position that acts as the
+// userinfo/host delimiter: the last raw '@', or a later percent-escape that encodes
+// '@' through any number of layers ("%40", "%2540", "%252540", ...). It returns -1
+// when neither is present. A raw '@' after such an escape wins, matching url.Parse,
+// which splits at the last raw '@'; an escape after the last raw '@' is the
+// dangerous case a raw search misses (the hybrid "admin:p@ssword%40host", issue
+// #62). Escapes that do not provably decode to '@' (a malformed "%zz", or "%4c" for
+// 'L') are not delimiters, so an ordinary encoded path is left intact.
+func lastAtDelimiter(s string) int {
+	at := strings.LastIndexByte(s, '@')
+	for i := len(s) - 1; i > at; i-- {
+		if s[i] == '%' && escapeEncodesAt(s[i:]) {
+			return i
+		}
+	}
+	return at
+}
+
+// escapeEncodesAt reports whether s begins with a percent-escape that decodes to
+// '@', including through nested encoding of any depth. '@' is 0x40, written "%40";
+// each further encoding layer wraps the leading '%' (0x25) as "%25", so the only
+// strings that decode to a leading '@' are "%40", "%2540", "%252540", and so on: a
+// '%', then zero or more literal "25", then "40". Both bytes have a unique two-hex
+// spelling ("40" and "25" contain no letters, so there is no case variant), so this
+// one forward scan is EXACTLY the layer-by-layer decode, and unlike peeling the
+// escape (which rebuilt the string each round) it allocates nothing and stays linear
+// on a crafted input. That matters because safeHost runs on an attacker-influenced
+// gateway X-Centreon-Host header (issue #62); an allocating peel was quadratic.
+func escapeEncodesAt(s string) bool {
+	if len(s) < 3 || s[0] != '%' {
+		return false
+	}
+	i := 1
+	for i+2 <= len(s) && s[i] == '2' && s[i+1] == '5' {
+		i += 2 // peel one "%25" layer
+	}
+	return i+2 <= len(s) && s[i] == '4' && s[i+1] == '0'
 }

--- a/config_test.go
+++ b/config_test.go
@@ -337,7 +337,13 @@ func TestSafeHost(t *testing.T) {
 		{"masks leading //authority userinfo", "//admin:sekret@centreon.example.com", "//admin:xxxxx@centreon.example.com"},
 		{"masks empty-scheme ://authority userinfo", "://admin:sekret@centreon.example.com", "://admin:xxxxx@centreon.example.com"},
 		{"masks userinfo with port and path", "https://admin:sekret@centreon.example.com:8443/mon?q=1", "https://admin:xxxxx@centreon.example.com:8443/mon?q=1"},
-		{"masks userinfo when the path also has @", "https://admin:sekret@centreon.example.com/p@th", "https://admin:xxxxx@centreon.example.com/p@th"},
+		// A '@' surviving after the authority is ambiguous: url.Parse's benign reading
+		// (host centreon.example.com, path /p@th) is byte-for-byte the credential
+		// reading (password sekret@centreon.example.com/p, host th), so safeHost fails
+		// closed and masks to the last '@' rather than leak a password of that shape
+		// (issue #62). The pre-colon text still greps. Same fail-closed rule the
+		// ambiguous colon-and-@ rows below already apply.
+		{"fails closed when a @ survives after the authority", "https://admin:sekret@centreon.example.com/p@th", "https://admin:xxxxx@th"},
 		// url.Parse fails outright on the bad percent-escape, so the textual fallback
 		// must still redact rather than return the raw credential.
 		{"masks userinfo in an unparseable URL", "https://admin:sekret@centreon.example.com/%zz", "https://admin:xxxxx@centreon.example.com/%zz"},
@@ -395,6 +401,62 @@ func TestSafeHost(t *testing.T) {
 		// A real parsed password plus a second password span in the tail: Redacted
 		// masks only the first, so this must fall through to the textual masker.
 		{"masks a password span in the tail beside real userinfo", "https://admin:pw@centreon.example.com/x:secret@evil.example.com", "https://admin:xxxxx@evil.example.com"},
+		// Issue #62, family 1: a password holding a raw '@' before a '/', '?' or '#'
+		// makes url.Parse decode only a fragment as userinfo and read the rest as
+		// host/path, so url.Redacted masks the fragment and leaves the rest verbatim.
+		// safeHost must fall through to the textual masker, which masks to the last '@'.
+		{"masks a raw @ password before a slash", "https://admin:se@cret/path@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		{"masks a raw @ password before a slash, second host", "https://user:pass1@pass2/word@centreon.example.com", "https://user:xxxxx@centreon.example.com"},
+		{"masks a raw @ password with a long tail", "https://admin:p@ssw0rdLONGSECRET/x@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		// Issue #62, family 2: the delimiter can arrive percent-encoded, so there is no
+		// raw '@' for the unchanged-return or the masker to key on; both decode it. The
+		// encoded delimiter is kept verbatim in the output so the host still greps.
+		{"masks a %40 delimiter after a slash", "https://admin:1234/SECRETpassword%40centreon.example.com", "https://admin:xxxxx%40centreon.example.com"},
+		{"masks a %40 delimiter after a question mark", "https://admin:1234?SECRETpassword%40centreon.example.com", "https://admin:xxxxx%40centreon.example.com"},
+		// A raw '@' in the password ahead of an encoded delimiter: the masker takes the
+		// LATER encoded '@' as the delimiter, so the whole span collapses to xxxxx.
+		{"masks a raw @ password ahead of an encoded delimiter", "https://admin:p@ssword%40centreon.example.com", "https://admin:xxxxx%40centreon.example.com"},
+		// Encoded twice, so a "%40" substring test would miss it; peeled up to 4 layers.
+		{"masks a double-encoded delimiter", "https://admin:1234/secret%2540centreon.example.com", "https://admin:xxxxx%2540centreon.example.com"},
+		{"masks the scheme-less encoded-delimiter form", "admin:secret%40centreon.example.com", "admin:xxxxx%40centreon.example.com"},
+		// Fail closed on an encoded delimiter behind a real port (the issue #61 trade:
+		// the port is masked, the pre-colon host still greps), the encoded analog of
+		// the ambiguous host:port-with-@ rows in this table.
+		{"fails closed on an encoded delimiter behind a port", "https://centreon.example.com:8443/report%40q", "https://centreon.example.com:xxxxx%40q"},
+		// Benign escapes with no password span before them must be left intact.
+		{"leaves an encoded @ with no colon before it unchanged", "https://centreon.example.com/report%40q", "https://centreon.example.com/report%40q"},
+		{"leaves an ordinary encoded space unchanged", "https://centreon.example.com/mon%20test", "https://centreon.example.com/mon%20test"},
+		{"leaves a non-delimiter escape unchanged", "https://centreon.example.com/pw%4chost", "https://centreon.example.com/pw%4chost"},
+		// A bracketed IPv6 authority is exempt, but an encoded password span in its
+		// tail is not; a colon-free encoded '@' in the tail still is exempt.
+		{"masks an encoded password span after a bracketed IPv6 authority", "https://[::1]/admin:secret%40evil.example.com", "https://[::1]/admin:xxxxx%40evil.example.com"},
+		{"leaves an IPv6 host with an encoded @ and no colon in the tail unchanged", "https://[::1]/x%40y", "https://[::1]/x%40y"},
+		// url.Parse rejects a '%40' inside an IPv6 zone (only '%25' is a valid zone
+		// escape), so safeHost reaches the textual masker. The '%40' must NOT be taken
+		// for a userinfo delimiter that masks from inside the address: the bracketed
+		// span is a valid IPv6 literal, so there is no credential and the host is left
+		// intact (issue #62; without the guard this masked to "[fe80:xxxxx%40en0]").
+		{"leaves an IPv6 host with a %40 zone unchanged", "https://[fe80::1%40en0]:8443", "https://[fe80::1%40en0]:8443"},
+		{"leaves an IPv6 host with a %40 zone and path unchanged", "https://[2001:db8::1%40x]/mon", "https://[2001:db8::1%40x]/mon"},
+		// The unclosed-bracket exemption must not fail open: a valid IP followed by a
+		// '%' and then a ':password' is NOT a zoned host, it hides a credential. Only
+		// the whole post-'[' span parsing as an IP earns the exemption, so this masks
+		// (masking a mis-parsed bracketed authority is the issue #61 trade, never a leak).
+		{"masks a password after a fake zone in an unclosed IPv6 bracket", "https://[192.168.0.1%x:secret@host", "https://[192.168.0.1%x:xxxxx@host"},
+		// The delimiter can be nested arbitrarily deep; the masker peels every layer,
+		// so a bound cannot be outrun to leave the password verbatim (5 layers here).
+		{"masks a five-layer encoded delimiter", "https://admin:secret%2525252540centreon.example.com", "https://admin:xxxxx%2525252540centreon.example.com"},
+		{"masks a raw @ password ahead of a five-layer encoded delimiter", "https://admin:p@ssword%2525252540centreon.example.com", "https://admin:xxxxx%2525252540centreon.example.com"},
+		// The issue #61 log-integrity trade extended to an encoded delimiter: once a
+		// real userinfo is decoded but a %40 survives in the tail, the input is the
+		// same ambiguous shape as a password whose own delimiter is encoded (compare
+		// "admin:x@SEKRIT/p%40host", where SEKRIT is password material). safeHost
+		// cannot tell them apart, so it fails closed and masks to the encoded '@',
+		// losing the host rather than risk leaking a password. A '%40' in the path or
+		// query of a Centreon base URL does not occur in practice, so this costs a log
+		// only on inputs that do not arise; it never leaks.
+		{"fails closed on an encoded @ in the path beside real userinfo", "https://admin:secret@centreon.example.com/api%40v1", "https://admin:xxxxx%40v1"},
+		{"fails closed on an encoded @ in the query beside real userinfo", "https://admin:secret@centreon.example.com?q=1%402", "https://admin:xxxxx%402"},
 		// A "//" inside the password used to pose as the authority marker, so the
 		// textual masker treated the real password as the authority and returned the
 		// host unmasked. Only a leading "//" or one behind a valid scheme counts now.
@@ -446,6 +508,12 @@ func TestSafeHostNeverLeaksPassword(t *testing.T) {
 	if len(grid) < 1000 {
 		t.Fatalf("credentialHostGrid() returned %d hosts, expected a full grid", len(grid))
 	}
+	// Also sweep the percent-encoded delimiter (issue #62 family 2), once and twice
+	// encoded. These inputs carry no raw '@', so before the fix safeHost either
+	// returned them unchanged or masked to a non-existent raw '@'; the marker
+	// survived. The display test does not get these joins, see its note.
+	grid = append(grid, credentialHostGridJoined("%40")...)
+	grid = append(grid, credentialHostGridJoined("%2540")...)
 
 	failures := 0
 	for _, host := range grid {
@@ -495,6 +563,12 @@ func namesAnIntendedHost(out string) bool {
 // hand-written TestDisplayHost rows were written from; those rows are the
 // reproduction, and this is the guard against the next shape.
 func TestDisplayHostNamesOnlyARealHost(t *testing.T) {
+	// Only the raw-'@' grid, not the "%40"/"%2540" joins the safeHost sweep adds.
+	// "%25" is legal in a host, so a double-encoded input like
+	// "https://admin:p@SEKRIT%2540centreon.example.com" parses with host
+	// "SEKRIT%2540centreon.example.com" and displayHost echoes it; that is a
+	// separate, pre-existing displayHost hole tracked outside issue #62, not a
+	// regression this test should assert against.
 	grid := credentialHostGrid()
 	if len(grid) < 1000 {
 		t.Fatalf("credentialHostGrid() returned %d hosts, expected a full grid", len(grid))
@@ -553,7 +627,17 @@ var credentialGridHosts = []string{
 // '#' in either the username or the password, an all-numeric password prefix that
 // parses as a port, an email-style username that moves the authority split onto the
 // wrong '@', and a second password span in the tail (issue #55).
-func credentialHostGrid() []string {
+func credentialHostGrid() []string { return credentialHostGridJoined("@") }
+
+// credentialHostGridJoined is credentialHostGrid parameterised by the bytes that
+// join the userinfo to the target. The raw "@" join is the credential form
+// url.Parse decodes and is what the display test and the raw-'@' half of the
+// safeHost sweep use. "%40" (and its multiply-encoded spelling "%2540") is the
+// percent-encoded delimiter of issue #62: it carries no raw '@' at all, so the
+// unchanged-return and the textual masker both have to decode it to find the
+// password span. Only the safeHost sweep feeds the encoded joins; the display
+// test deliberately does not (see the note there).
+func credentialHostGridJoined(join string) []string {
 	schemes := []string{"https://", "http://", "//", "://", "", "https:"}
 	usernames := []string{
 		"admin", "us/er", "us?er", "us#er", "us.er", "[user", "us[er",
@@ -570,6 +654,11 @@ func credentialHostGrid() []string {
 		"#" + passwordMarker, "aB9/" + passwordMarker, passwordMarker + "/tail",
 		"1234/sec:" + passwordMarker, "pw/" + passwordMarker, "p@" + passwordMarker,
 		"pw//" + passwordMarker, "pw://" + passwordMarker, "aB9//" + passwordMarker,
+		// Marker AFTER an internal '@' and before a '/', '?' or '#'. url.Parse decodes
+		// the pre-'@' fragment as userinfo and reads the marker as the host, so
+		// url.Redacted masks only the fragment and the marker leaks; the marker-only
+		// assertion can finally see the family-1 class (issue #62).
+		"x@" + passwordMarker + "/p", "x@" + passwordMarker + "?q", "x@" + passwordMarker + "#f",
 	}
 	hosts := credentialGridHosts
 	tails := []string{"", "/mon", "?q=1", "#f", "/a@b", "/d:" + passwordMarker + "@f"}
@@ -592,7 +681,7 @@ func credentialHostGrid() []string {
 	for _, scheme := range schemes {
 		for _, userinfo := range userinfos {
 			for _, target := range targets {
-				grid = append(grid, scheme+userinfo+"@"+target)
+				grid = append(grid, scheme+userinfo+join+target)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`safeHost` redacts a password from a Centreon host URL before it reaches a log field (CWE-532); in gateway mode the value can come from the caller-supplied `X-Centreon-Host` header, so an attacker partly controls it. Two credential families survived the #55/#57 hardening and are closed here.

Family 1, a password holding a raw `@` before a `/`, `?` or `#`: `url.Parse` decodes only the pre-`@` fragment as userinfo, so `url.Redacted` masks that fragment and leaves the rest verbatim (`admin:se@cret/path@host` leaked `cret/path`). Family 2, a percent-encoded `%40` delimiter: with no raw `@`, the input was returned unchanged, whole password included.

`safeHost` now routes both to its textual masker. `redactedCoversCredential` and the scheme-less reparse guard stop trusting `url.Redacted` whenever an `@` (raw or `%40`-encoded) survives after the authority `url.Parse` chose, using a new `afterAuthorityDelimiter` helper to reproduce Parse's split point textually. The masker locates the delimiter with `lastAtDelimiter`, whose `escapeEncodesAt` recognises a `%40` nested to any depth (`%2540`, `%252540`, ...) in a single allocation-free forward scan, so a crafted deeply-nested header cannot drive it quadratic. The encoded delimiter is kept verbatim so the host after it still greps.

Consistent with the #61 trade, an ambiguous input (a `%40` in the path or query beside a real credential, byte-identical to the shape where that span is password material) fails closed and masks to the encoded `@` rather than risk a leak; it never leaks, and the shape does not arise in a Centreon base URL. A bracketed IPv6 literal whose zone carries an invalid `%40` is exempt: `url.Parse` rejects it and the masker treats the valid address as the host rather than masking inside it.

`displayHost` is untouched, so its tool-response contract (#48) and tests are unchanged.

## Related Issues

Fixes #62. A deeper encoding where the delimiter's own hex digits are percent-encoded (`%25%34%30`) is out of scope and pre-existing; filed as #68.

## Test Plan

- [x] `go test ./...` and `go test -race ./...` pass
- [x] `TestSafeHostNeverLeaksPassword` sweeps the `@`, `%40` and `%2540` joins plus a marker-as-leaked-fragment family-1 shape (about 70,000 inputs)
- [x] New `TestSafeHost` rows cover both families, the 5-layer nesting, the IPv6 `%40`-zone cases, and the fail-closed `%40`-in-tail trade
- [x] `go vet`, `gofmt`, and `golangci-lint` clean