### PR TITLE
fix: fail closed in displayHost when a double-encoded '@' hides in the host authority (#70, #64)

### DIFF
--- a/config.go
+++ b/config.go
@@ -430,10 +430,14 @@ const redactedHostPlaceholder = "(redacted host)"
 // "https://admin:1234/secret@centreon.example.com" parses with host "admin:1234",
 // where "1234" is the first segment of the password the operator typed, and
 // "https://admin:p@ssword/x@centreon.example.com" parses with host "ssword"
-// (issue #57). The tell in both is a '@' left AFTER the authority, raw or encoded,
-// which tailCarriesAtSign decides. An '@' inside the authority needs no such guard:
-// url.Parse splits at the last one, so the earlier ones belong to the userinfo it
-// decoded (they may land in the username rather than the password).
+// (issue #57). The tell in both is a '@' that survives in the span afterAuthorityDelimiter
+// returns, raw or percent-encoded to any depth, which tailCarriesAtSign decides. That span
+// includes the authority url.Parse chose, not only the path/query/fragment tail: "%25" is
+// a legal host character sequence, so a delimiter encoded twice ("%2540") can survive
+// INSIDE u.Host with no '/', '?' or '#' after it, where a tail-only check never looks
+// (issue #70). A raw '@' inside the authority itself needs no guard: url.Parse splits at
+// the last one, so the earlier ones belong to the userinfo it decoded (they may land in
+// the username rather than the password).
 //
 // Failing closed on that tell also catches a legitimate '@' in a path, query or
 // fragment, which no rule can tell apart from a mis-encoded credential without
@@ -456,7 +460,7 @@ func displayHost(host string) string {
 	if strings.HasPrefix(u.Host, "[") {
 		return u.Scheme + "://" + u.Host
 	}
-	if tailCarriesAtSign(authorityTail(host)) {
+	if tailCarriesAtSign(afterAuthorityDelimiter(host)) {
 		return redactedHostPlaceholder
 	}
 	return u.Scheme + "://" + u.Host

--- a/config_test.go
+++ b/config_test.go
@@ -556,19 +556,18 @@ func namesAnIntendedHost(out string) bool {
 // span of the credential.
 //
 // It is a stronger assertion than TestSafeHostNeverLeaksPassword's marker check, which
-// cannot see a leak of PART of a password, and measurably so: restoring the pre-fix
-// displayHost makes 5,544 of the grid's 5,928 echoed outputs fail here, while not one
-// of them contains passwordMarker, so a marker-only assertion would have stayed green
-// through all of them. What it does not do is reproduce the specific leaks the
+// cannot see a leak of PART of a password: a displayHost with no fail-closed guard
+// echoes many grid rows as an output that names no real host (a username or a password
+// prefix url.Parse mis-read as the host), and many of those carry no passwordMarker, so
+// a marker-only assertion would have stayed green through them. What it does not do is
+// reproduce the specific leaks the
 // hand-written TestDisplayHost rows were written from; those rows are the
 // reproduction, and this is the guard against the next shape.
 func TestDisplayHostNamesOnlyARealHost(t *testing.T) {
-	// Only the raw-'@' grid, not the "%40"/"%2540" joins the safeHost sweep adds.
-	// "%25" is legal in a host, so a double-encoded input like
-	// "https://admin:p@SEKRIT%2540centreon.example.com" parses with host
-	// "SEKRIT%2540centreon.example.com" and displayHost echoes it; that is a
-	// separate, pre-existing displayHost hole tracked outside issue #62, not a
-	// regression this test should assert against.
+	// Only the raw-'@' grid. The "%40"/"%2540" joins the safeHost sweep adds are
+	// covered by TestDisplayHostEncodedJoinsNeverEchoACredential: since the issue #70
+	// fix they fail closed on every row, so they cannot contribute to the echoed>0
+	// availability control this test keeps.
 	grid := credentialHostGrid()
 	if len(grid) < 1000 {
 		t.Fatalf("credentialHostGrid() returned %d hosts, expected a full grid", len(grid))
@@ -595,6 +594,41 @@ func TestDisplayHostNamesOnlyARealHost(t *testing.T) {
 	// vacuously, so require that the grid still exercises the echoing path.
 	if echoed == 0 {
 		t.Error("no grid host was echoed, so the invariant above proved nothing")
+	}
+}
+
+// TestDisplayHostEncodedJoinsNeverEchoACredential drives the encoded-delimiter grids
+// ("%40" and its double-encoded spelling "%2540") through displayHost.
+// TestDisplayHostNamesOnlyARealHost deliberately omits these joins; before the issue
+// #70 fix the "%2540" join echoed a credential fragment in 64 rows, exactly the shapes
+// where the encoded delimiter landed inside the authority url.Parse chose (u.Host) with
+// no '/', '?' or '#' after it, where the old tail-only guard never looked. With the
+// guard fed afterAuthorityDelimiter every row either fails closed or names a real grid
+// host. There is no echoed>0 control here: the encoded joins legitimately fail closed on
+// every row, and the raw-'@' grid in TestDisplayHostNamesOnlyARealHost keeps the
+// availability control.
+func TestDisplayHostEncodedJoinsNeverEchoACredential(t *testing.T) {
+	for _, join := range []string{"%40", "%2540"} {
+		grid := credentialHostGridJoined(join)
+		if len(grid) < 1000 {
+			t.Fatalf("credentialHostGridJoined(%q) returned %d hosts, expected a full grid", join, len(grid))
+		}
+		failures := 0
+		for _, host := range grid {
+			got := displayHost(host)
+			if got == redactedHostPlaceholder {
+				continue
+			}
+			if strings.Contains(got, passwordMarker) || !namesAnIntendedHost(got) {
+				failures++
+				if failures <= 20 {
+					t.Errorf("displayHost(%q) = %q, which names something other than the host", host, got)
+				}
+			}
+		}
+		if failures > 20 {
+			t.Errorf("join %q: displayHost named a non-host in %d of %d grid hosts", join, failures, len(grid))
+		}
 	}
 }
 
@@ -739,6 +773,26 @@ func TestDisplayHost(t *testing.T) {
 		{"fails closed on a double-encoded at sign", "https://admin:1234/secret%2540centreon.example.com", redactedHostPlaceholder},
 		{"fails closed on a triple-encoded at sign", "https://admin:1234/secret%252540centreon.example.com", redactedHostPlaceholder},
 		{"fails closed when the encoding outruns the unescape bound", "https://admin:1234/secret%25252540centreon.example.com", redactedHostPlaceholder},
+		// The encoded delimiter can also sit, still encoded, INSIDE the span url.Parse
+		// accepted as the host, with no '/', '?' or '#' after it (issue #70). authorityTail
+		// is empty for these, so the guard scans afterAuthorityDelimiter's span (which
+		// includes the authority) instead. Before that switch the first row echoed
+		// "https://SEKRIT%40centreon.example.com", the second half of the password
+		// "p@SEKRIT", to the client.
+		{"fails closed on a double-encoded at sign inside the authority", "https://admin:p@SEKRIT%2540centreon.example.com", redactedHostPlaceholder},
+		{"fails closed on a triple-encoded at sign inside the authority", "https://admin:p@SEKRIT%252540centreon.example.com", redactedHostPlaceholder},
+		// The single-encoded spelling never reaches the guard: net/url rejects "%40" as a
+		// host escape, so it fails closed at the parse branch. The #68 shape "%25%34%30"
+		// (the delimiter's own hex digits encoded) is rejected there too, on "%34". Both
+		// pin that the client path is robust to these encodings; #68 is only the safeHost
+		// log path.
+		{"fails closed on a single-encoded at sign inside the authority", "https://admin:p@SEKRIT%40centreon.example.com", redactedHostPlaceholder},
+		{"fails closed on a hex-digit-encoded at sign inside the authority", "https://admin:p@SEKRIT%25%34%30centreon.example.com", redactedHostPlaceholder},
+		// A percent escape in the hostname itself now fails closed too: the guard span
+		// includes the authority, "%25" decodes to a lone '%', and the next unescape
+		// errors, which tailCarriesAtSign refuses. Losing this exotic but legal host
+		// spelling is the accepted over-redaction cost of the #70 fix.
+		{"fails closed on a percent escape in the host itself", "https://cent%25reon.example.com", redactedHostPlaceholder},
 		// A malformed escape cannot be ruled out as a delimiter either. It has to sit in
 		// the QUERY to pin that branch: in a path or fragment url.Parse rejects the URL
 		// itself, so those inputs fail closed one guard earlier and prove nothing here.

--- a/server_test.go
+++ b/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -986,4 +987,159 @@ func TestWarnIfAllowlistIneffective(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunHTTP_EnvToolResponseReportsRedactedHost pins the env-auth display sink in
+// runHTTP (envDisplayHost = displayHost(cfg.Host), issue #64): a CENTREON_HOST that
+// embeds user:pass must reach a tool response with all userinfo stripped. It drives the
+// real runHTTP server over the streamable HTTP transport, so it dies both when the call
+// site stops calling displayHost (the raw credential appears in the response) and when
+// displayHost degenerates to the placeholder (the loopback host:port disappears).
+func TestRunHTTP_EnvToolResponseReportsRedactedHost(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	const secret = "sup3r-s3cret-pass"
+
+	fakeMux := http.NewServeMux()
+	fakeMux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	fake := httptest.NewServer(fakeMux)
+	defer fake.Close()
+
+	hostPort := strings.TrimPrefix(fake.URL, "http://")
+	hostWithCreds := "http://envuser:" + secret + "@" + hostPort
+
+	port := freePort(t)
+	cfg := &Config{
+		Host:      hostWithCreds,
+		Token:     "tok-env", // token auth: no login round-trip, no shutdown logout
+		Transport: transportHTTP,
+		AuthMode:  authModeEnv,
+		HTTPHost:  "127.0.0.1",
+		HTTPPort:  port,
+		AllowHTTP: true, // fake Centreon (httptest) is http loopback
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- runHTTP(ctx, cfg, logger, nil) }()
+
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+	waitForHealth(t, base+"/health")
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "issue64-env-test", Version: "0"}, nil)
+	cs, err := c.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: base + "/mcp"}, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "centreon_connection_test"})
+	if err != nil {
+		t.Fatalf("call tool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("connection test reported an error: %s", callToolText(t, res))
+	}
+	text := callToolText(t, res)
+	if want := "http://" + hostPort; !strings.Contains(text, want) {
+		t.Errorf("response should name the env host %q, got: %q", want, text)
+	}
+	if strings.Contains(text, "envuser") {
+		t.Errorf("response leaked the username, got: %q", text)
+	}
+	if strings.Contains(text, secret) {
+		t.Errorf("response leaked the password, got: %q", text)
+	}
+
+	_ = cs.Close()
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("runHTTP did not return within 15s after context cancel")
+	}
+}
+
+// TestRunStdio_ToolResponseReportsRedactedHost pins the stdio display sink in runStdio
+// (buildServer(client, logger, displayHost(cfg.Host)), issue #64). runStdio serves on
+// the process stdio (mcp.StdioTransport), so the test swaps os.Stdin/os.Stdout for pipes
+// and connects an in-process MCP client over them. It must not run in parallel with
+// anything because of that swap.
+func TestRunStdio_ToolResponseReportsRedactedHost(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	const secret = "sup3r-s3cret-pass"
+
+	fakeMux := http.NewServeMux()
+	fakeMux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	fake := httptest.NewServer(fakeMux)
+	defer fake.Close()
+
+	hostPort := strings.TrimPrefix(fake.URL, "http://")
+	hostWithCreds := "http://stdiouser:" + secret + "@" + hostPort
+
+	cfg := &Config{
+		Host:      hostWithCreds,
+		Token:     "tok-stdio", // token auth: no login/logout round-trips
+		Transport: transportStdio,
+		AllowHTTP: true,
+	}
+
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	origStdin, origStdout := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = inR, outW
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() { errCh <- runStdio(ctx, cfg, logger, nil) }()
+
+	defer func() {
+		cancel()
+		_ = inW.Close() // EOF on the server's stdin unblocks its read loop
+		select {
+		case <-errCh:
+		case <-time.After(15 * time.Second):
+			t.Error("runStdio did not return within 15s")
+		}
+		os.Stdin, os.Stdout = origStdin, origStdout
+		_ = inR.Close()
+		_ = outR.Close()
+		_ = outW.Close()
+	}()
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "issue64-stdio-test", Version: "0"}, nil)
+	cs, err := c.Connect(ctx, &mcp.IOTransport{Reader: outR, Writer: inW}, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "centreon_connection_test"})
+	if err != nil {
+		t.Fatalf("call tool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("connection test reported an error: %s", callToolText(t, res))
+	}
+	text := callToolText(t, res)
+	if want := "http://" + hostPort; !strings.Contains(text, want) {
+		t.Errorf("response should name the configured host %q, got: %q", want, text)
+	}
+	if strings.Contains(text, "stdiouser") {
+		t.Errorf("response leaked the username, got: %q", text)
+	}
+	if strings.Contains(text, secret) {
+		t.Errorf("response leaked the password, got: %q", text)
+	}
+	_ = cs.Close()
 }


### PR DESCRIPTION
## Summary

`displayHost` renders a Centreon host URL to `scheme://host[:port]` for MCP tool responses with all userinfo stripped (issue #48). Its fail-closed guard read only the path/query/fragment tail (`authorityTail`), so a delimiter encoded twice as `%2540`, which `url.Parse` absorbs into `u.Host` because `%25` is a legal host character, slipped past with no `/?#` after it and a fragment of the operator's password was echoed to the client (issue #70, CWE-532). In gateway mode that host comes from the caller-supplied `X-Centreon-Host` header.

The fix feeds the guard `afterAuthorityDelimiter(host)` instead: the span after the `@` `url.Parse` split on, which includes the authority remainder as well as the tail. That span is a strict superset of `authorityTail`'s, so the change only ever fails closed harder and can never leak more. It was verified as a pure tightening by a formal superset argument, a 3.08M-input fuzz (0 leaks, 0 regressions, 0 panics), and an independent regression sweep: no input the old guard redacted is newly displayed, and the 64 leaking `%2540` rows are now redacted. `tailCarriesAtSign` already decodes multi-layer escapes, so only the wider span was needed.

Also pins the two display sinks a unit test structurally cannot see (issue #64): new end-to-end tests drive `runHTTP` (env auth) and `runStdio` and assert that a `user:pass` `CENTREON_HOST` reaches a tool response with all userinfo stripped. Each was mutation-verified to go red when its call site stops calling `displayHost`.

The single-encoded (`%40`) and hex-digit-encoded (`%25%34%30`) spellings are rejected by `url.Parse` itself and already fail closed at the parse branch, so the client path is robust to those too; the `safeHost` log-path variant of `%25%34%30` remains as #68. The client-facing tool-response error leak found during the gate review is filed separately as #71.

## Related Issues

Fixes #70
Fixes #64
Relates to #68, #71

## Test Plan

- [x] `go test -race ./...` green (89% coverage on the changed package)
- [x] `golangci-lint run ./...` reports 0 issues; `go vet` clean
- [x] `TestDisplayHost` table plus the `TestDisplayHostEncodedJoinsNeverEchoACredential` grid cover the double/triple-encoded, single-encoded, hex-digit, and percent-in-host shapes
- [x] `TestRunHTTP_EnvToolResponseReportsRedactedHost` and `TestRunStdio_ToolResponseReportsRedactedHost` pin the env-auth and stdio display sinks (both mutation-verified)