### PR TITLE
fix: classify Centreon client-call errors before logs or clients see them (#63, #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Security
+
+- Centreon client-call errors are now classified to a fixed, credential-safe
+  description before they reach a server log or an MCP tool response, so a
+  credential embedded in the base URL (`CENTREON_HOST`, or a caller-supplied
+  `X-Centreon-Host` header in gateway mode) can no longer leak through an error
+  value, including the mis-parsed-authority case where Go's own masking sees no
+  userinfo to hide (CWE-532). (#63, #71)
+
+### Changed
+
+- Breaking: a cleartext `http://` Centreon host is rejected by default. Existing
+  `http://` deployments must set `CENTREON_ALLOW_HTTP=true` to opt back in. (#28)
+- Breaking: a host URL that names no hostname is rejected. The port-only forms
+  `http://:8080` (with `CENTREON_ALLOW_HTTP=true`) and `https://:8443` (with
+  `CENTREON_ALLOW_SELF_SIGNED=true`) previously worked because Go treats an empty
+  hostname as localhost. Write the hostname out, for example `localhost:8080`.
+  This also changes the outgoing `Host` header from `:8080` to `localhost:8080`,
+  so a name-based reverse proxy in front of Centreon may route differently
+  afterwards. (#57, #58)
+- When a Centreon host URL carries a legitimate `@` after the authority, the
+  read-only status and connection tools report the literal `(redacted host)`
+  instead of a host name, because the authority cannot be identified without
+  risking exposure of a credential. (#66)
+
+## [1.0.0]
+
+- Initial tagged release.
+
+[Unreleased]: https://github.com/tphakala/centreon-mcp-go/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/tphakala/centreon-mcp-go/releases/tag/v1.0.0

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,89 @@
+// Package redact turns an error into a short, credential-safe description fit
+// for a server log or an MCP tool response (CWE-532).
+//
+// A Centreon base URL can carry userinfo (user:pass@host), from CENTREON_HOST
+// or, in gateway mode, from a caller-supplied X-Centreon-Host header. When a
+// request against it fails, net/http builds a *url.Error whose text embeds that
+// base URL, and url.Error.Error masks only what url.Parse decoded as userinfo:
+// a mis-parsed authority (https://admin:1234/pw@host, where url.Parse read
+// "admin" as the host and decoded no userinfo) prints the whole typed password,
+// and even a well-formed URL leaks the username. Wrapped resolver, TLS, and
+// upstream API errors can carry the same bytes. Issues #63 (server log) and #71
+// (client response) both need one routine that keeps those bytes out of a sink.
+package redact
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+
+	centreon "github.com/tphakala/centreon-go-client"
+)
+
+// ErrCrossHostRedirect is the sentinel the redirect guard wraps so Reason can
+// classify a refused cross-host redirect without importing the guard's package.
+var ErrCrossHostRedirect = errors.New("refusing cross-host redirect")
+
+// Reason maps err to a short, fixed description safe for logs and MCP tool
+// responses. The hard invariant that makes it fail closed: it never copies a
+// string field out of the error chain. It calls no err.Error(), and reads no
+// APIError.Message, net.DNSError.Name, or url.Error.URL, because any of those
+// can hold the request URL and the credential typed into it, including spans
+// url.Parse never decoded as userinfo. Only compile-time strings and the trusted
+// HTTP status integer are emitted; an unrecognised error falls through to a
+// constant. A new error type nobody anticipated therefore lands on the
+// fail-closed default rather than leaking, and adding a leak takes a deliberate
+// edit that reads a string field, not an omission.
+func Reason(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.Canceled):
+		return "request cancelled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "request timed out"
+	case errors.Is(err, ErrCrossHostRedirect):
+		return "cross-host redirect refused"
+	}
+
+	// Concrete upstream and network types first, so a *net.DNSError wrapped in a
+	// *url.Error is classified by the resolver failure ("DNS lookup failed")
+	// rather than by the generic *url.Error branch below. Only the integer
+	// HTTPStatus is surfaced from an APIError; its Message is the upstream
+	// response body, remote-controlled (in gateway mode by an attacker-chosen
+	// host), so it is dropped.
+	if e, ok := errors.AsType[*centreon.APIError](err); ok {
+		return fmt.Sprintf("centreon API error (HTTP %d)", e.HTTPStatus)
+	}
+	if _, ok := errors.AsType[*centreon.NotFoundError](err); ok {
+		return "resource not found"
+	}
+	if _, ok := errors.AsType[*net.DNSError](err); ok {
+		return "DNS lookup failed"
+	}
+	if _, ok := errors.AsType[*tls.CertificateVerificationError](err); ok {
+		return "TLS certificate verification failed"
+	}
+
+	// A timeout can arrive as any net.Error (including a *url.Error whose inner
+	// error timed out), so check the interface before the concrete URL branches.
+	if ne, ok := errors.AsType[net.Error](err); ok && ne.Timeout() {
+		return "network timeout"
+	}
+
+	// Op is a stdlib constant, never request data, so it is safe to read.
+	if e, ok := errors.AsType[*url.Error](err); ok {
+		if e.Op == "parse" {
+			return "invalid URL"
+		}
+		return "network error"
+	}
+	if _, ok := errors.AsType[*net.OpError](err); ok {
+		return "network error"
+	}
+
+	return "request failed"
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,139 @@
+package redact_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+
+	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
+)
+
+// secret is the password marker planted throughout the fixtures. No Reason
+// output may ever contain it, nor the username fragment "admin".
+const (
+	secret = "s3cr3tpw"
+	user   = "admin"
+)
+
+// misparsedErr reproduces the exact leak measured in issues #63 and #71: a base
+// URL whose password holds a '/', so url.Parse reads "admin" as the host and
+// never decodes userinfo. http.Client.Do wraps the resolver failure in a
+// *url.Error whose URL field prints the whole typed credential, and the wrapped
+// *net.DNSError.Name is the credential fragment "admin".
+func misparsedErr() error {
+	return &url.Error{
+		Op:  "Get",
+		URL: "https://admin:1234/" + secret + "@centreon.invalid/login",
+		Err: &net.DNSError{Err: "no such host", Name: user, IsNotFound: true},
+	}
+}
+
+// timeoutError is a net.Error whose message embeds the secret and which reports a
+// timeout, so it exercises the net.Error timeout branch without matching an
+// earlier concrete-type branch.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "dial https://" + user + ":" + secret + "@h: i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return false }
+
+func TestReason(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"canceled", fmt.Errorf("wrap: %w", context.Canceled), "request cancelled"},
+		{"deadline", fmt.Errorf("wrap: %w", context.DeadlineExceeded), "request timed out"},
+		{
+			"cross-host redirect",
+			fmt.Errorf("outer: %w", fmt.Errorf("%w from %q to %q", redact.ErrCrossHostRedirect, "a", "b")),
+			"cross-host redirect refused",
+		},
+		{
+			"api error drops message",
+			&centreon.APIError{HTTPStatus: 401, Message: "login as " + user + ":" + secret},
+			"centreon API error (HTTP 401)",
+		},
+		{
+			"not found",
+			&centreon.NotFoundError{Resource: "host", ID: 7},
+			"resource not found",
+		},
+		{"misparsed dns", misparsedErr(), "DNS lookup failed"},
+		{
+			"tls verification",
+			&url.Error{Op: "Get", URL: "https://" + user + ":" + secret + "@h/x", Err: &tls.CertificateVerificationError{}},
+			"TLS certificate verification failed",
+		},
+		{
+			"parse error",
+			&url.Error{Op: "parse", URL: "https://u:" + secret + "@", Err: errors.New("missing host")},
+			"invalid URL",
+		},
+		{"net timeout", timeoutError{}, "network timeout"},
+		{
+			"generic op error",
+			&url.Error{Op: "Get", URL: "https://" + user + ":" + secret + "@h/x", Err: &net.OpError{Op: "dial", Err: errors.New("connection refused")}},
+			"network error",
+		},
+		{
+			// Bare *net.OpError (not wrapped in a *url.Error): exercises the
+			// standalone OpError branch, which the wrapped row above skips.
+			"bare op error",
+			&net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			"network error",
+		},
+		{
+			"unknown fails closed",
+			errors.New(`Get "https://` + user + ":" + secret + `@x": boom`),
+			"request failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := redact.Reason(tt.err)
+			if got != tt.want {
+				t.Fatalf("Reason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReason_NeverEmitsCredential is the masking-is-active control: every error
+// shape that can carry a credential is fed through Reason and the output must
+// contain neither the password marker nor the username fragment. Changing any
+// classifier branch to return err.Error() (or a raw URL/Name field) turns this
+// red. (Deleting a branch does not: the fixture then falls through to another
+// credential-safe constant; the sibling TestReason equality table catches a
+// deleted or misrouted branch.)
+func TestReason_NeverEmitsCredential(t *testing.T) {
+	t.Parallel()
+	errs := []error{
+		misparsedErr(),
+		&centreon.APIError{HTTPStatus: 500, Message: "boom " + user + ":" + secret},
+		&url.Error{Op: "Get", URL: "https://" + user + ":" + secret + "@h/api", Err: &net.DNSError{Name: user}},
+		&url.Error{Op: "Get", URL: "https://" + user + ":" + secret + "@h/api", Err: errors.New("dial tcp: connection refused")},
+		&net.DNSError{Err: "no such host", Name: user + ":" + secret},
+		timeoutError{},
+		fmt.Errorf("centreon: create request: %w", &url.Error{Op: "parse", URL: "https://" + user + ":" + secret + "@"}),
+	}
+	for i, err := range errs {
+		got := redact.Reason(err)
+		if strings.Contains(got, secret) {
+			t.Errorf("case %d: Reason() = %q leaked password marker %q", i, got, secret)
+		}
+		if strings.Contains(got, user) {
+			t.Errorf("case %d: Reason() = %q leaked username %q", i, got, user)
+		}
+	}
+}

--- a/server.go
+++ b/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 	"github.com/tphakala/centreon-mcp-go/tools"
 	"golang.org/x/sync/errgroup"
 )
@@ -93,7 +94,10 @@ func noCrossHostRedirect(req *http.Request, via []*http.Request) error {
 	}
 	origin := via[0].URL.Hostname()
 	if target := req.URL.Hostname(); !strings.EqualFold(target, origin) {
-		return fmt.Errorf("refusing cross-host redirect from %q to %q", origin, target)
+		// Wrap the sentinel so redact.Reason can classify this guard across the
+		// *url.Error that http.Client.Do wraps it in, without importing this
+		// package. The sentinel's own text still contains "cross-host redirect".
+		return fmt.Errorf("%w from %q to %q", redact.ErrCrossHostRedirect, origin, target)
 	}
 	return nil
 }
@@ -197,12 +201,12 @@ func run(ctx context.Context, cfg *Config, logger *slog.Logger) error {
 func runStdio(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *http.Client, transport mcp.Transport) error {
 	client, err := newCentreonClient(cfg.Host, cfg, logger, httpClient)
 	if err != nil {
-		return fmt.Errorf("creating centreon client: %w", err)
+		return fmt.Errorf("creating centreon client for host %s: %s", safeHost(cfg.Host), redact.Reason(err))
 	}
 
 	if cfg.Token == "" {
 		if err := client.Login(ctx); err != nil {
-			return fmt.Errorf("centreon login: %w", err)
+			return fmt.Errorf("centreon login failed (host %s): %s", safeHost(cfg.Host), redact.Reason(err))
 		}
 		defer logoutClientBounded(ctx, client, logger)
 		logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
@@ -230,7 +234,7 @@ func logoutClientBounded(ctx context.Context, client *centreon.Client, logger *s
 	logoutCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownLogoutTimeout)
 	defer cancel()
 	if err := client.Logout(logoutCtx); err != nil {
-		logger.Debug("centreon client logout failed", "error", err)
+		logger.Debug("centreon client logout failed", "error", redact.Reason(err))
 	} else {
 		logger.Info("centreon client logged out")
 	}
@@ -248,11 +252,11 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 	if cfg.AuthMode == authModeEnv {
 		client, err := newCentreonClient(cfg.Host, cfg, logger, httpClient)
 		if err != nil {
-			return fmt.Errorf("creating centreon client: %w", err)
+			return fmt.Errorf("creating centreon client for host %s: %s", safeHost(cfg.Host), redact.Reason(err))
 		}
 		if cfg.Token == "" {
 			if err := client.Login(ctx); err != nil {
-				return fmt.Errorf("centreon login: %w", err)
+				return fmt.Errorf("centreon login failed (host %s): %s", safeHost(cfg.Host), redact.Reason(err))
 			}
 			logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
 		}
@@ -350,7 +354,7 @@ func gracefulShutdown(serveCtx context.Context, httpServer *http.Server, sharedC
 
 	if sharedClient != nil && cfg.Token == "" {
 		if err := sharedClient.Logout(logoutCtx); err != nil {
-			logger.Debug("centreon client logout failed", "error", err)
+			logger.Debug("centreon client logout failed", "error", redact.Reason(err))
 		} else {
 			logger.Info("centreon client logged out")
 		}
@@ -402,13 +406,13 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 
 	client, err := newCentreonClient(host, gwCfg, logger, httpClient)
 	if err != nil {
-		logger.Error("gateway: failed to create client", "host", safeHost(host), "error", err)
+		logger.Error("gateway: failed to create client", "host", safeHost(host), "error", redact.Reason(err))
 		return nil
 	}
 
 	if gwCfg.Token == "" {
 		if err := client.Login(r.Context()); err != nil {
-			logger.Error("gateway: authentication failed", "host", safeHost(host), "error", err)
+			logger.Error("gateway: authentication failed", "host", safeHost(host), "error", redact.Reason(err))
 			return nil
 		}
 		// Cache the token for subsequent requests
@@ -477,11 +481,11 @@ func logoutCachedToken(ctx context.Context, host, token string, logger *slog.Log
 	gwCfg := &Config{Token: token}
 	client, err := newCentreonClient(host, gwCfg, nil, httpClient)
 	if err != nil {
-		logger.Debug("gateway: failed to build client for token logout", "host", safeHost(host), "error", err)
+		logger.Debug("gateway: failed to build client for token logout", "host", safeHost(host), "error", redact.Reason(err))
 		return
 	}
 	if err := client.Logout(ctx); err != nil {
-		logger.Debug("gateway: token logout failed", "host", safeHost(host), "error", err)
+		logger.Debug("gateway: token logout failed", "host", safeHost(host), "error", redact.Reason(err))
 		return
 	}
 	logger.Debug("gateway: logged out cached token", "host", safeHost(host))

--- a/server_redact_test.go
+++ b/server_redact_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// leakMarker is the password planted in a mis-parsed host URL across these
+// tests. The mis-parsed shape (a '/' inside the password) is the one from
+// issues #63 and #71: url.Parse reads "admin" as the host and decodes no
+// userinfo, so http.Client prints the whole typed password in its *url.Error.
+const leakMarker = "s3cr3tpw"
+
+// misparsedHost is a base URL whose password holds a '/', so the credential
+// survives into the request URL and any resulting *url.Error.
+const misparsedHost = "https://admin:1234/" + leakMarker + "@centreon.invalid"
+
+// failDNSClient is an http.Client whose transport fails every request with a
+// resolver error, so a login or logout deterministically produces the
+// credential-bearing *url.Error without touching real DNS.
+func failDNSClient() *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, &net.DNSError{Err: "no such host", Name: "admin", IsNotFound: true}
+	})}
+}
+
+// logRecordByMsg returns the first JSON log record in buf whose "msg" equals
+// want. It lets a test inspect one specific sink's attributes while ignoring
+// the centreon client's own request-failure log line (the upstream residual
+// tphakala/centreon-go-client#42, out of scope here), which this repo cannot
+// intercept because the client formats and emits it directly.
+func logRecordByMsg(t *testing.T, buf *bytes.Buffer, want string) map[string]any {
+	t.Helper()
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] == want {
+			return rec
+		}
+	}
+	t.Fatalf("no log record with msg=%q in: %s", want, buf.String())
+	return nil
+}
+
+// TestRunStdio_LoginErrorRedacted pins that a failed startup login does not
+// carry the credential out through the error returned to main (CWE-532, #63).
+// It asserts on the return value, not a log buffer, so the client's own request
+// logging cannot confound it.
+func TestRunStdio_LoginErrorRedacted(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.DiscardHandler)
+	cfg := &Config{Host: misparsedHost, Username: "admin", Password: leakMarker}
+
+	err := runStdio(t.Context(), cfg, logger, failDNSClient(), nil)
+	if err == nil {
+		t.Fatal("want a login error, got nil")
+	}
+	if strings.Contains(err.Error(), leakMarker) {
+		t.Errorf("login error leaked credential (CWE-532): %v", err)
+	}
+	if !strings.Contains(err.Error(), "centreon login") {
+		t.Errorf("want the login-failure wrap to stay identifiable, got: %v", err)
+	}
+}
+
+// TestLogoutCachedToken_LogNeverLeaksCredential pins that the gateway
+// token-logout Debug sinks (#63) do not print the credential-bearing host URL.
+// logoutCachedToken builds its client with a nil logger, so the buffer holds
+// only this function's own lines; no client residual can confound it.
+func TestLogoutCachedToken_LogNeverLeaksCredential(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	logoutCachedToken(t.Context(), misparsedHost, "tok", logger, failDNSClient())
+
+	out := buf.String()
+	if strings.Contains(out, leakMarker) {
+		t.Errorf("token-logout log leaked credential (CWE-532): %s", out)
+	}
+	if !strings.Contains(out, "gateway: token logout failed") {
+		t.Errorf("want the logout-failure line, got: %s", out)
+	}
+}
+
+// TestGatewayServer_AuthFailureLogRedactsError pins the highest-concern #63
+// sink: gateway auth failure, where the host is the caller-supplied
+// X-Centreon-Host header. It inspects only the "gateway: authentication failed"
+// record, so the client's separate request-failure line (#42) does not mask a
+// regression in our sink.
+func TestGatewayServer_AuthFailureLogRedactsError(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+	r.Header.Set("X-Centreon-Host", misparsedHost)
+	r.Header.Set("X-Centreon-Username", "admin")
+	r.Header.Set("X-Centreon-Password", leakMarker)
+
+	cache := NewTokenCache(time.Minute)
+	if srv := gatewayServer(r, &Config{}, cache, logger, failDNSClient()); srv != nil {
+		t.Fatal("want nil server on auth failure")
+	}
+
+	rec := logRecordByMsg(t, &buf, "gateway: authentication failed")
+	errVal, _ := rec["error"].(string)
+	if strings.Contains(errVal, leakMarker) {
+		t.Errorf("auth-failure error attribute leaked credential (CWE-532): %q", errVal)
+	}
+	if errVal != "DNS lookup failed" {
+		t.Errorf("auth-failure error attribute = %q, want the classified reason %q", errVal, "DNS lookup failed")
+	}
+	if hostVal, _ := rec["host"].(string); strings.Contains(hostVal, leakMarker) {
+		t.Errorf("auth-failure host attribute leaked credential (CWE-532): %q", hostVal)
+	}
+}

--- a/tools/acknowledgement_tools.go
+++ b/tools/acknowledgement_tools.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterAcknowledgementTools registers all acknowledgement tools.
@@ -91,8 +92,9 @@ func acknowledgementGetHandler(client *centreon.Client, logger *slog.Logger) fun
 		logger.Debug("centreon_acknowledgement_get", "id", in.ID)
 		ack, err := client.Acknowledgements.Get(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_acknowledgement_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get acknowledgement %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_acknowledgement_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get acknowledgement %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(ack)
@@ -108,8 +110,9 @@ func acknowledgementHostListHandler(client *centreon.Client, logger *slog.Logger
 		opts := buildListOptions(listIn)
 		resp, err := client.Acknowledgements.ListForHost(ctx, in.HostID, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_acknowledgement_host_list", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to list acknowledgements for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_acknowledgement_host_list", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to list acknowledgements for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(resp)
@@ -125,8 +128,9 @@ func acknowledgementServiceListHandler(client *centreon.Client, logger *slog.Log
 		opts := buildListOptions(listIn)
 		resp, err := client.Acknowledgements.ListForService(ctx, in.HostID, in.ServiceID, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_acknowledgement_service_list", "error", err, "hostID", in.HostID, "serviceID", in.ServiceID)
-			res, anyVal := errorResult("failed to list acknowledgements for service (host=%d, service=%d): %v", in.HostID, in.ServiceID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_acknowledgement_service_list", "error", reason, "hostID", in.HostID, "serviceID", in.ServiceID)
+			res, anyVal := errorResult("failed to list acknowledgements for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(resp)
@@ -146,8 +150,9 @@ func acknowledgementHostCreateHandler(client *centreon.Client, logger *slog.Logg
 			WithServices:        in.WithServices,
 		}
 		if err := client.Acknowledgements.CreateForHost(ctx, in.HostID, ackReq); err != nil {
-			logger.Error("failed: centreon_acknowledgement_host_create", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to create acknowledgement for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_acknowledgement_host_create", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to create acknowledgement for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_acknowledgement_host_create", "Acknowledgement created for host %d", in.HostID)
@@ -166,8 +171,9 @@ func acknowledgementServiceCreateHandler(client *centreon.Client, logger *slog.L
 			IsPersistentComment: in.IsPersistentComment,
 		}
 		if err := client.Acknowledgements.CreateForService(ctx, in.HostID, in.ServiceID, ackReq); err != nil {
-			logger.Error("failed: centreon_acknowledgement_service_create", "error", err, "hostID", in.HostID, "serviceID", in.ServiceID)
-			res, anyVal := errorResult("failed to create acknowledgement for service (host=%d, service=%d): %v", in.HostID, in.ServiceID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_acknowledgement_service_create", "error", reason, "hostID", in.HostID, "serviceID", in.ServiceID)
+			res, anyVal := errorResult("failed to create acknowledgement for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_acknowledgement_service_create", "Acknowledgement created for service %d on host %d", in.ServiceID, in.HostID)
@@ -180,8 +186,9 @@ func acknowledgementHostCancelHandler(client *centreon.Client, logger *slog.Logg
 		ctx = centreon.WithToolName(ctx, "centreon_acknowledgement_host_cancel")
 		logger.Info("centreon_acknowledgement_host_cancel", "hostID", in.HostID)
 		if err := client.Acknowledgements.CancelForHost(ctx, in.HostID); err != nil {
-			logger.Error("failed: centreon_acknowledgement_host_cancel", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to cancel acknowledgement for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_acknowledgement_host_cancel", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to cancel acknowledgement for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_acknowledgement_host_cancel", "Acknowledgement cancelled for host %d", in.HostID)
@@ -194,8 +201,9 @@ func acknowledgementServiceCancelHandler(client *centreon.Client, logger *slog.L
 		ctx = centreon.WithToolName(ctx, "centreon_acknowledgement_service_cancel")
 		logger.Info("centreon_acknowledgement_service_cancel", "hostID", in.HostID, "serviceID", in.ServiceID)
 		if err := client.Acknowledgements.CancelForService(ctx, in.HostID, in.ServiceID); err != nil {
-			logger.Error("failed: centreon_acknowledgement_service_cancel", "error", err, "hostID", in.HostID, "serviceID", in.ServiceID)
-			res, anyVal := errorResult("failed to cancel acknowledgement for service (host=%d, service=%d): %v", in.HostID, in.ServiceID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_acknowledgement_service_cancel", "error", reason, "hostID", in.HostID, "serviceID", in.ServiceID)
+			res, anyVal := errorResult("failed to cancel acknowledgement for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_acknowledgement_service_cancel", "Acknowledgement cancelled for service %d on host %d", in.ServiceID, in.HostID)

--- a/tools/common_list_redact_test.go
+++ b/tools/common_list_redact_test.go
@@ -1,0 +1,33 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	centreon "github.com/tphakala/centreon-go-client"
+)
+
+// TestCommonListHandler_ErrorNeverEchoesCredential pins the single sink shared
+// by every list tool that routes through commonListHandler (#63, #71): a
+// client-call error carrying the base-URL credential must be classified before
+// it reaches the log or the response. Changing the redact.Reason call in
+// commonListHandler to pass the raw err turns this red.
+func TestCommonListHandler_ErrorNeverEchoesCredential(t *testing.T) {
+	requester := func(_ context.Context, _ ...centreon.ListOption) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+		return nil, misparsedClientErr()
+	}
+
+	res, _, err := commonListHandler(t.Context(), testLogger(t), "centreon_host_list", ListInput{}, requester)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error result")
+	}
+	text := textOf(t, res)
+	assertNoCredential(t, text)
+	if !strings.Contains(text, "centreon_host_list") || !strings.Contains(text, "DNS lookup failed") {
+		t.Errorf("want the tool named and the reason classified, got: %q", text)
+	}
+}

--- a/tools/connection_tools.go
+++ b/tools/connection_tools.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterConnectionTools registers all connection tools. host is the
@@ -33,8 +34,12 @@ func connectionTestHandlerFn(fetchStatus func(context.Context) (*centreon.HostSt
 		logger.Debug("centreon_connection_test")
 		_, err := fetchStatus(ctx)
 		if err != nil {
-			logger.Error("failed: centreon_connection_test", "error", err)
-			res, anyVal := errorResult("connection failed: %v", err)
+			// Classify the error before it reaches the log or the client: an
+			// upstream *url.Error can embed the base-URL credential (CWE-532;
+			// #63, #71), and neither sink may carry it.
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_connection_test", "error", reason)
+			res, anyVal := errorResult("connection failed: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := textResult("Connection successful (host: %s)", host)

--- a/tools/connection_tools_test.go
+++ b/tools/connection_tools_test.go
@@ -48,7 +48,42 @@ func TestConnectionTestHandlerFn_ErrorOmitsHost(t *testing.T) {
 	if !res.IsError {
 		t.Fatal("expected error result")
 	}
-	if got, want := textOf(t, res), "connection failed: boom"; got != want {
+	if got, want := textOf(t, res), "connection failed: request failed"; got != want {
 		t.Errorf("result text = %q, want %q", got, want)
+	}
+}
+
+// TestConnectionTestHandlerFn_ErrorNeverEchoesCredential pins #71 for this tool:
+// a client-call error carrying the base-URL credential must be classified before
+// it reaches the response, so neither the mis-parsed password nor the username
+// leaks. Deleting the redact.Reason call at connection_tools.go:37 turns this red.
+func TestConnectionTestHandlerFn_ErrorNeverEchoesCredential(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"mis-parsed authority", misparsedClientErr(), "connection failed: DNS lookup failed"},
+		{"well-formed userinfo leaks username", wellFormedClientErr(), "connection failed: network error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fetch := func(context.Context) (*centreon.HostStatusCount, error) {
+				return nil, tc.err
+			}
+			handler := connectionTestHandlerFn(fetch, testLogger(t), "https://centreon.example.com")
+			res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatal("expected error result")
+			}
+			text := textOf(t, res)
+			assertNoCredential(t, text)
+			if text != tc.want {
+				t.Errorf("result text = %q, want %q", text, tc.want)
+			}
+		})
 	}
 }

--- a/tools/downtime_tools.go
+++ b/tools/downtime_tools.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterDowntimeTools registers all downtime tools.
@@ -100,8 +101,9 @@ func downtimeGetHandler(client *centreon.Client, logger *slog.Logger) func(ctx c
 		logger.Debug("centreon_downtime_get", "id", in.ID)
 		downtime, err := client.Downtimes.Get(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_downtime_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get downtime %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_downtime_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get downtime %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(downtime)
@@ -114,8 +116,9 @@ func downtimeCancelHandler(client *centreon.Client, logger *slog.Logger) func(ct
 		ctx = centreon.WithToolName(ctx, "centreon_downtime_cancel")
 		logger.Info("centreon_downtime_cancel", "id", in.ID)
 		if err := client.Downtimes.Cancel(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_downtime_cancel", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to cancel downtime %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_downtime_cancel", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to cancel downtime %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_downtime_cancel", "Downtime %d cancelled", in.ID)
@@ -131,8 +134,9 @@ func downtimeHostListHandler(client *centreon.Client, logger *slog.Logger) func(
 		opts := buildListOptions(listIn)
 		resp, err := client.Downtimes.ListForHost(ctx, in.HostID, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_downtime_host_list", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to list downtimes for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_downtime_host_list", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to list downtimes for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(resp)
@@ -148,8 +152,9 @@ func downtimeServiceListHandler(client *centreon.Client, logger *slog.Logger) fu
 		opts := buildListOptions(listIn)
 		resp, err := client.Downtimes.ListForService(ctx, in.HostID, in.ServiceID, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_downtime_service_list", "error", err, "hostID", in.HostID, "serviceID", in.ServiceID)
-			res, anyVal := errorResult("failed to list downtimes for service (host=%d, service=%d): %v", in.HostID, in.ServiceID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_downtime_service_list", "error", reason, "hostID", in.HostID, "serviceID", in.ServiceID)
+			res, anyVal := errorResult("failed to list downtimes for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(resp)
@@ -184,8 +189,9 @@ func downtimeHostCreateHandler(client *centreon.Client, logger *slog.Logger) fun
 			WithServices: in.WithServices,
 		}
 		if err := client.Downtimes.CreateForHost(ctx, in.HostID, downtimeReq); err != nil {
-			logger.Error("failed: centreon_downtime_host_create", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to create downtime for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_downtime_host_create", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to create downtime for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_downtime_host_create", "Downtime scheduled for host %d", in.HostID)
@@ -221,8 +227,9 @@ func downtimeServiceCreateHandler(client *centreon.Client, logger *slog.Logger) 
 			Duration:  in.Duration,
 		}
 		if err := client.Downtimes.CreateForService(ctx, in.HostID, in.ServiceID, downtimeReq); err != nil {
-			logger.Error("failed: centreon_downtime_service_create", "error", err, "hostID", in.HostID, "serviceID", in.ServiceID)
-			res, anyVal := errorResult("failed to create downtime for service (host=%d, service=%d): %v", in.HostID, in.ServiceID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_downtime_service_create", "error", reason, "hostID", in.HostID, "serviceID", in.ServiceID)
+			res, anyVal := errorResult("failed to create downtime for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_downtime_service_create", "Downtime scheduled for service %d on host %d", in.ServiceID, in.HostID)
@@ -235,8 +242,9 @@ func downtimeHostCancelHandler(client *centreon.Client, logger *slog.Logger) fun
 		ctx = centreon.WithToolName(ctx, "centreon_downtime_host_cancel")
 		logger.Info("centreon_downtime_host_cancel", "hostID", in.HostID)
 		if err := client.Downtimes.CancelForHost(ctx, in.HostID); err != nil {
-			logger.Error("failed: centreon_downtime_host_cancel", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to cancel downtimes for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_downtime_host_cancel", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to cancel downtimes for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_downtime_host_cancel", "Downtime cancelled for host %d", in.HostID)
@@ -249,8 +257,9 @@ func downtimeServiceCancelHandler(client *centreon.Client, logger *slog.Logger) 
 		ctx = centreon.WithToolName(ctx, "centreon_downtime_service_cancel")
 		logger.Info("centreon_downtime_service_cancel", "hostID", in.HostID, "serviceID", in.ServiceID)
 		if err := client.Downtimes.CancelForService(ctx, in.HostID, in.ServiceID); err != nil {
-			logger.Error("failed: centreon_downtime_service_cancel", "error", err, "hostID", in.HostID, "serviceID", in.ServiceID)
-			res, anyVal := errorResult("failed to cancel downtimes for service (host=%d, service=%d): %v", in.HostID, in.ServiceID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_downtime_service_cancel", "error", reason, "hostID", in.HostID, "serviceID", in.ServiceID)
+			res, anyVal := errorResult("failed to cancel downtimes for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_downtime_service_cancel", "Downtime cancelled for service %d on host %d", in.ServiceID, in.HostID)

--- a/tools/host_config_tools.go
+++ b/tools/host_config_tools.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterHostConfigTools registers all host configuration tools.
@@ -227,8 +228,9 @@ func hostGetHandler(client *centreon.Client, logger *slog.Logger) func(ctx conte
 		logger.Debug("centreon_host_get", "id", in.ID)
 		host, err := client.Hosts.GetByID(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_host_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get host %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get host %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(host)
@@ -258,8 +260,9 @@ func hostCreateHandler(client *centreon.Client, logger *slog.Logger) func(ctx co
 			Macros:             macros,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_host_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create host %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create host %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_create", "Created host with ID %d", id)
@@ -283,8 +286,9 @@ func hostUpdateHandler(client *centreon.Client, logger *slog.Logger) func(ctx co
 			IsActivated:         in.IsActivated,
 		}
 		if err := client.Hosts.Update(ctx, in.ID, &req); err != nil {
-			logger.Error("failed: centreon_host_update", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to update host %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_update", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to update host %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_update", "Updated host %d", in.ID)
@@ -297,8 +301,9 @@ func hostDeleteHandler(client *centreon.Client, logger *slog.Logger) func(ctx co
 		ctx = centreon.WithToolName(ctx, "centreon_host_delete")
 		logger.Info("centreon_host_delete", "id", in.ID)
 		if err := client.Hosts.Delete(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_host_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete host %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete host %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_delete", "Deleted host %d", in.ID)
@@ -318,8 +323,9 @@ func hostGroupGetHandler(client *centreon.Client, logger *slog.Logger) func(ctx 
 		logger.Debug("centreon_host_group_get", "id", in.ID)
 		hg, err := client.HostGroups.Get(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_host_group_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get host group %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_group_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get host group %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(hg)
@@ -336,8 +342,9 @@ func hostGroupCreateHandler(client *centreon.Client, logger *slog.Logger) func(c
 			Alias: in.Alias,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_host_group_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create host group %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_group_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create host group %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_group_create", "Created host group with ID %d", id)
@@ -353,8 +360,9 @@ func hostGroupUpdateHandler(client *centreon.Client, logger *slog.Logger) func(c
 			Name:  in.Name,
 			Alias: in.Alias,
 		}); err != nil {
-			logger.Error("failed: centreon_host_group_update", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to update host group %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_group_update", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to update host group %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_group_update", "Updated host group %d", in.ID)
@@ -367,8 +375,9 @@ func hostGroupDeleteHandler(client *centreon.Client, logger *slog.Logger) func(c
 		ctx = centreon.WithToolName(ctx, "centreon_host_group_delete")
 		logger.Info("centreon_host_group_delete", "id", in.ID)
 		if err := client.HostGroups.Delete(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_host_group_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete host group %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_group_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete host group %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_group_delete", "Deleted host group %d", in.ID)
@@ -391,8 +400,9 @@ func hostCategoryGetHandlerFn(
 		logger.Debug("centreon_host_category_get", "id", in.ID)
 		cat, err := fn(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_host_category_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get host category %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_category_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get host category %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(cat)
@@ -416,8 +426,9 @@ func hostCategoryCreateHandlerFn(
 			Alias: in.Alias,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_host_category_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create host category %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_category_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create host category %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_category_create", "Created host category with ID %d", id)
@@ -440,8 +451,9 @@ func hostCategoryUpdateHandlerFn(
 			Name:  in.Name,
 			Alias: in.Alias,
 		}); err != nil {
-			logger.Error("failed: centreon_host_category_update", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to update host category %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_category_update", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to update host category %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_category_update", "Updated host category %d", in.ID)
@@ -461,8 +473,9 @@ func hostCategoryDeleteHandlerFn(
 		ctx = centreon.WithToolName(ctx, "centreon_host_category_delete")
 		logger.Info("centreon_host_category_delete", "id", in.ID)
 		if err := fn(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_host_category_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete host category %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_category_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete host category %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_category_delete", "Deleted host category %d", in.ID)
@@ -483,8 +496,9 @@ func hostSeverityGetHandlerFn(
 		logger.Debug("centreon_host_severity_get", "id", in.ID)
 		sev, err := fn(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_host_severity_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get host severity %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_severity_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get host severity %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(sev)
@@ -510,8 +524,9 @@ func hostSeverityCreateHandlerFn(
 			IconID: in.IconID,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_host_severity_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create host severity %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_severity_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create host severity %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_severity_create", "Created host severity with ID %d", id)
@@ -536,8 +551,9 @@ func hostSeverityUpdateHandlerFn(
 			Level:  in.Level,
 			IconID: in.IconID,
 		}); err != nil {
-			logger.Error("failed: centreon_host_severity_update", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to update host severity %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_severity_update", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to update host severity %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_severity_update", "Updated host severity %d", in.ID)
@@ -557,8 +573,9 @@ func hostSeverityDeleteHandlerFn(
 		ctx = centreon.WithToolName(ctx, "centreon_host_severity_delete")
 		logger.Info("centreon_host_severity_delete", "id", in.ID)
 		if err := fn(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_host_severity_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete host severity %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_host_severity_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete host severity %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_host_severity_delete", "Deleted host severity %d", in.ID)

--- a/tools/host_config_tools_test.go
+++ b/tools/host_config_tools_test.go
@@ -1,13 +1,47 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
 )
+
+// TestHostCategoryGetHandlerFn_ErrorNeverEchoesCredential pins one config
+// handler end to end (#63, #71): a mis-parsed base-URL credential must reach
+// neither the response nor the log. Each swept handler has its OWN inline
+// redact.Reason sink (same pattern, independent code), so this guards
+// hostCategoryGetHandlerFn specifically; the other per-handler sinks across the
+// tools package are exercised by TestToolHandlers_ErrorNeverEchoesCredential
+// (redact_sweep_test.go). Changing the redact.Reason call in
+// hostCategoryGetHandlerFn to pass the raw err turns this red.
+func TestHostCategoryGetHandlerFn_ErrorNeverEchoesCredential(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fn := func(_ context.Context, _ int) (*centreon.HostCategory, error) {
+		return nil, misparsedClientErr()
+	}
+	handler := hostCategoryGetHandlerFn(fn, logger)
+	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, IDInput{ID: 99})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error result")
+	}
+	text := textOf(t, res)
+	assertNoCredential(t, text)
+	assertNoCredential(t, buf.String())
+	if !strings.Contains(text, "host category 99") || !strings.Contains(text, "DNS lookup failed") {
+		t.Errorf("want the target identified and the reason classified, got: %q", text)
+	}
+}
 
 // ---- Host Category ----
 

--- a/tools/infra_tools.go
+++ b/tools/infra_tools.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterInfraTools registers all infrastructure tools.
@@ -100,8 +101,9 @@ func pollerApplyHandlerFn(
 		ctx = centreon.WithToolName(ctx, "centreon_poller_apply")
 		logger.Info("centreon_poller_apply", "pollerID", in.PollerID)
 		if err := fn(ctx, in.PollerID); err != nil {
-			logger.Error("failed: centreon_poller_apply", "error", err, "pollerID", in.PollerID)
-			res, anyVal := errorResult("failed to apply configuration for poller %d: %v", in.PollerID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_poller_apply", "error", reason, "pollerID", in.PollerID)
+			res, anyVal := errorResult("failed to apply configuration for poller %d: %s", in.PollerID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_poller_apply", "Applied configuration for poller %d", in.PollerID)
@@ -117,8 +119,9 @@ func pollerApplyAllHandlerFn(
 		ctx = centreon.WithToolName(ctx, "centreon_poller_apply_all")
 		logger.Info("centreon_poller_apply_all")
 		if err := fn(ctx); err != nil {
-			logger.Error("failed: centreon_poller_apply_all", "error", err)
-			res, anyVal := errorResult("failed to apply configuration for all pollers: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_poller_apply_all", "error", reason)
+			res, anyVal := errorResult("failed to apply configuration for all pollers: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_poller_apply_all", "Applied configuration for all pollers")
@@ -158,8 +161,9 @@ func timePeriodGetHandler(client *centreon.Client, logger *slog.Logger) func(ctx
 		logger.Debug("centreon_time_period_get", "id", in.ID)
 		tp, err := client.TimePeriods.Get(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_time_period_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get time period %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_time_period_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get time period %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(tp)
@@ -181,8 +185,9 @@ func timePeriodCreateHandler(client *centreon.Client, logger *slog.Logger) func(
 			Days:  days,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_time_period_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create time period %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_time_period_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create time period %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_time_period_create", "Created time period with ID %d", id)
@@ -207,8 +212,9 @@ func timePeriodUpdateHandlerFn(
 			Days:      days,
 			Templates: in.Templates,
 		}); err != nil {
-			logger.Error("failed: centreon_time_period_update", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to update time period %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_time_period_update", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to update time period %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_time_period_update", "Updated time period %d", in.ID)
@@ -228,8 +234,9 @@ func timePeriodDeleteHandlerFn(
 		ctx = centreon.WithToolName(ctx, "centreon_time_period_delete")
 		logger.Info("centreon_time_period_delete", "id", in.ID)
 		if err := fn(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_time_period_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete time period %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_time_period_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete time period %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_time_period_delete", "Deleted time period %d", in.ID)

--- a/tools/monitoring_tools.go
+++ b/tools/monitoring_tools.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterMonitoringTools registers all monitoring tools.
@@ -80,8 +81,9 @@ func monitoringHostListHandler(client *centreon.Client, logger *slog.Logger) fun
 		opts := buildMonitoringListOptions(in)
 		resp, err := client.MonitoringHosts.List(ctx, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_host_list", "error", err)
-			res, anyVal := errorResult("failed: centreon_monitoring_host_list: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_host_list", "error", reason)
+			res, anyVal := errorResult("failed: centreon_monitoring_host_list: %s", reason)
 			return res, anyVal, nil
 		}
 		logger.Debug("centreon_monitoring_host_list completed", "results", len(resp.Result), "total", resp.Meta.Total)
@@ -96,8 +98,9 @@ func monitoringHostGetHandler(client *centreon.Client, logger *slog.Logger) func
 		logger.Debug("centreon_monitoring_host_get", "id", in.ID)
 		host, err := client.MonitoringHosts.Get(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_host_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get monitoring host %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_host_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get monitoring host %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(host)
@@ -113,8 +116,9 @@ func monitoringHostServicesHandler(client *centreon.Client, logger *slog.Logger)
 		opts := buildMonitoringListOptions(listIn)
 		resp, err := client.MonitoringHosts.Services(ctx, in.HostID, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_host_services", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to list services for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_host_services", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to list services for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(resp)
@@ -130,8 +134,9 @@ func monitoringHostTimelineHandler(client *centreon.Client, logger *slog.Logger)
 		opts := buildMonitoringListOptions(listIn)
 		resp, err := client.MonitoringHosts.Timeline(ctx, in.HostID, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_host_timeline", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to get timeline for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_host_timeline", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to get timeline for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(resp)
@@ -145,8 +150,9 @@ func monitoringHostStatusCountsHandler(client *centreon.Client, logger *slog.Log
 		logger.Debug("centreon_monitoring_host_status_counts")
 		counts, err := client.MonitoringHosts.StatusCounts(ctx)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_host_status_counts", "error", err)
-			res, anyVal := errorResult("failed to get host status counts: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_host_status_counts", "error", reason)
+			res, anyVal := errorResult("failed to get host status counts: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(counts)
@@ -161,8 +167,9 @@ func monitoringServiceListHandler(client *centreon.Client, logger *slog.Logger) 
 		opts := buildMonitoringListOptions(in)
 		resp, err := client.MonitoringServices.List(ctx, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_service_list", "error", err)
-			res, anyVal := errorResult("failed: centreon_monitoring_service_list: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_service_list", "error", reason)
+			res, anyVal := errorResult("failed: centreon_monitoring_service_list: %s", reason)
 			return res, anyVal, nil
 		}
 		logger.Debug("centreon_monitoring_service_list completed", "results", len(resp.Result), "total", resp.Meta.Total)
@@ -177,8 +184,9 @@ func monitoringServiceStatusCountsHandler(client *centreon.Client, logger *slog.
 		logger.Debug("centreon_monitoring_service_status_counts")
 		counts, err := client.MonitoringServices.StatusCounts(ctx)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_service_status_counts", "error", err)
-			res, anyVal := errorResult("failed to get service status counts: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_service_status_counts", "error", reason)
+			res, anyVal := errorResult("failed to get service status counts: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(counts)
@@ -290,8 +298,9 @@ func monitoringResourceListHandler(client *centreon.Client, logger *slog.Logger)
 		}
 		resp, err := client.Monitoring.List(ctx, opts...)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_resource_list", "error", err)
-			res, anyVal := errorResult("failed: centreon_monitoring_resource_list: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_resource_list", "error", reason)
+			res, anyVal := errorResult("failed: centreon_monitoring_resource_list: %s", reason)
 			return res, anyVal, nil
 		}
 		logger.Debug("centreon_monitoring_resource_list completed", "results", len(resp.Result), "total", resp.Meta.Total)
@@ -306,8 +315,9 @@ func monitoringResourceHostGetHandler(client *centreon.Client, logger *slog.Logg
 		logger.Debug("centreon_monitoring_resource_host_get", "id", in.ID)
 		host, err := client.Monitoring.GetHost(ctx, in.ID)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_resource_host_get", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to get monitoring resource host %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_resource_host_get", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to get monitoring resource host %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(host)
@@ -321,8 +331,9 @@ func monitoringResourceServiceGetHandler(client *centreon.Client, logger *slog.L
 		logger.Debug("centreon_monitoring_resource_service_get", "hostID", in.HostID, "serviceID", in.ServiceID)
 		svc, err := client.Monitoring.GetService(ctx, in.HostID, in.ServiceID)
 		if err != nil {
-			logger.Error("failed: centreon_monitoring_resource_service_get", "error", err, "hostID", in.HostID, "serviceID", in.ServiceID)
-			res, anyVal := errorResult("failed to get monitoring resource service (host=%d, service=%d): %v", in.HostID, in.ServiceID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_monitoring_resource_service_get", "error", reason, "hostID", in.HostID, "serviceID", in.ServiceID)
+			res, anyVal := errorResult("failed to get monitoring resource service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(svc)

--- a/tools/notification_tools.go
+++ b/tools/notification_tools.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterNotificationTools registers all notification policy tools.
@@ -29,8 +30,9 @@ func notificationPolicyHostGetHandler(client *centreon.Client, logger *slog.Logg
 		logger.Debug("centreon_notification_policy_host_get", "hostID", in.HostID)
 		np, err := client.NotificationPolicies.GetForHost(ctx, in.HostID)
 		if err != nil {
-			logger.Error("failed: centreon_notification_policy_host_get", "error", err, "hostID", in.HostID)
-			res, anyVal := errorResult("failed to get notification policy for host %d: %v", in.HostID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_notification_policy_host_get", "error", reason, "hostID", in.HostID)
+			res, anyVal := errorResult("failed to get notification policy for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(np)
@@ -44,8 +46,9 @@ func notificationPolicyServiceGetHandler(client *centreon.Client, logger *slog.L
 		logger.Debug("centreon_notification_policy_service_get", "hostID", in.HostID, "serviceID", in.ServiceID)
 		np, err := client.NotificationPolicies.GetForService(ctx, in.HostID, in.ServiceID)
 		if err != nil {
-			logger.Error("failed: centreon_notification_policy_service_get", "error", err, "hostID", in.HostID, "serviceID", in.ServiceID)
-			res, anyVal := errorResult("failed to get notification policy for service (host=%d, service=%d): %v", in.HostID, in.ServiceID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_notification_policy_service_get", "error", reason, "hostID", in.HostID, "serviceID", in.ServiceID)
+			res, anyVal := errorResult("failed to get notification policy for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := jsonResult(np)

--- a/tools/operations_tools.go
+++ b/tools/operations_tools.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterOperationsTools registers all bulk operation tools.
@@ -69,8 +70,9 @@ func bulkAcknowledgeHandler(client *centreon.Client, logger *slog.Logger) func(c
 			IsPersistentComment: in.IsPersistentComment,
 		}
 		if err := client.Operations.Acknowledge(ctx, req); err != nil {
-			logger.Error("failed: centreon_resource_acknowledge", "error", err)
-			res, anyVal := errorResult("failed to acknowledge: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_resource_acknowledge", "error", reason)
+			res, anyVal := errorResult("failed to acknowledge: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_resource_acknowledge", "Acknowledged %s %d", in.Type, in.ID)
@@ -121,8 +123,9 @@ func bulkDowntimeHandler(client *centreon.Client, logger *slog.Logger) func(ctx 
 			Duration:  in.Duration,
 		}
 		if err := client.Operations.Downtime(ctx, downtimeReq); err != nil {
-			logger.Error("failed: centreon_resource_downtime", "error", err)
-			res, anyVal := errorResult("failed to schedule downtime: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_resource_downtime", "error", reason)
+			res, anyVal := errorResult("failed to schedule downtime: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_resource_downtime", "Scheduled downtime for %s %d", in.Type, in.ID)
@@ -149,8 +152,9 @@ func bulkCheckHandler(client *centreon.Client, logger *slog.Logger) func(ctx con
 			Resources: []centreon.ResourceRef{ref},
 		}
 		if err := client.Operations.Check(ctx, req); err != nil {
-			logger.Error("failed: centreon_resource_check", "error", err)
-			res, anyVal := errorResult("failed to force check: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_resource_check", "error", reason)
+			res, anyVal := errorResult("failed to force check: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_resource_check", "Forced check for %s %d", in.Type, in.ID)
@@ -189,8 +193,9 @@ func bulkSubmitHandler(client *centreon.Client, logger *slog.Logger) func(ctx co
 			},
 		}
 		if err := client.Operations.Submit(ctx, req); err != nil {
-			logger.Error("failed: centreon_resource_submit", "error", err)
-			res, anyVal := errorResult("failed to submit check result: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_resource_submit", "error", reason)
+			res, anyVal := errorResult("failed to submit check result: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_resource_submit", "Submitted check result for %s %d (status=%d)", in.Type, in.ID, in.Status)
@@ -219,8 +224,9 @@ func bulkCommentHandler(client *centreon.Client, logger *slog.Logger) func(ctx c
 			Comment:   in.Comment,
 		}
 		if err := client.Operations.Comment(ctx, req); err != nil {
-			logger.Error("failed: centreon_resource_comment", "error", err)
-			res, anyVal := errorResult("failed to add comment: %v", err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_resource_comment", "error", reason)
+			res, anyVal := errorResult("failed to add comment: %s", reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_resource_comment", "Added comment to %s %d", in.Type, in.ID)

--- a/tools/redact_fixtures_test.go
+++ b/tools/redact_fixtures_test.go
@@ -1,0 +1,57 @@
+package tools
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// Shared fixtures for the credential-leak tests across the tools package
+// (issues #63 and #71). Every tool handler that surfaces a Centreon client-call
+// error must route it through redact.Reason so a credential embedded in the
+// base URL never reaches the client response or the log.
+
+const (
+	// leakPassword is the password marker planted in a mis-parsed base URL.
+	leakPassword = "s3cr3tpw"
+	// leakUser is the username fragment url.Parse mis-reads as the host.
+	leakUser = "leakuser"
+)
+
+// misparsedClientErr reproduces the mis-parsed-authority leak measured in #63
+// and #71: a '/' inside the password makes url.Parse read leakUser as the host
+// and decode no userinfo, so http.Client prints the whole typed credential in
+// its *url.Error and the wrapped *net.DNSError.Name is the username fragment.
+func misparsedClientErr() error {
+	return &url.Error{
+		Op:  "Get",
+		URL: "https://" + leakUser + ":1234/" + leakPassword + "@centreon.invalid/monitoring/hosts",
+		Err: &net.DNSError{Err: "no such host", Name: leakUser, IsNotFound: true},
+	}
+}
+
+// wellFormedClientErr carries a correctly-formed userinfo URL. In production Go's
+// stripPassword would mask the password on such a URL but leave the username, so
+// an unredacted sink leaks at least leakUser. This fixture hardcodes the raw URL
+// into *url.Error.URL (so both fragments are literally present); the point is
+// that redact.Reason must classify it so neither fragment reaches a sink.
+func wellFormedClientErr() error {
+	return &url.Error{
+		Op:  "Get",
+		URL: "https://" + leakUser + ":" + leakPassword + "@centreon.example.com/monitoring/hosts",
+		Err: errors.New("dial tcp: connection refused"),
+	}
+}
+
+// assertNoCredential fails when s carries either planted credential fragment.
+func assertNoCredential(t *testing.T, s string) {
+	t.Helper()
+	if strings.Contains(s, leakPassword) {
+		t.Errorf("leaked password marker (CWE-532): %q", s)
+	}
+	if strings.Contains(s, leakUser) {
+		t.Errorf("leaked username (CWE-532): %q", s)
+	}
+}

--- a/tools/redact_sweep_test.go
+++ b/tools/redact_sweep_test.go
@@ -1,0 +1,84 @@
+package tools
+
+import (
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	centreon "github.com/tphakala/centreon-go-client"
+)
+
+// failRoundTripper fails every request with a resolver error, so a client call
+// deterministically yields a credential-bearing *url.Error without real DNS.
+type failRoundTripper struct{}
+
+func (failRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, &net.DNSError{Err: "no such host", Name: leakUser, IsNotFound: true}
+}
+
+// credBaseURL is a base URL whose password holds a '/', so url.Parse reads
+// leakUser as the host and the credential survives into every request URL and
+// the resulting *url.Error (the #63/#71 leak shape).
+const credBaseURL = "https://" + leakUser + ":1234/" + leakPassword + "@centreon.invalid"
+
+// TestToolHandlers_ErrorNeverEchoesCredential is the structural regression guard
+// for the per-handler redact.Reason sinks (#63, #71). Each get/create/update/
+// delete/cancel handler carries its OWN inline sink (same pattern, independent
+// code), so the shared-choke-point tests (commonListHandler, logReadError) do
+// not cover them. This drives one representative own-sink handler per otherwise
+// untested client subsystem against a real centreon.Client whose base URL
+// carries a credential and whose every request fails, and asserts the
+// client-facing response never contains the credential. Reverting redact.Reason
+// in any covered handler turns its row red.
+//
+// Not exhaustive: it samples a handful of the per-handler sinks. Full per-sink
+// coverage (every get/create/update/delete/cancel handler, plus the operations,
+// user, service and infra families) is tracked as a follow-up (issue #73).
+func TestToolHandlers_ErrorNeverEchoesCredential(t *testing.T) {
+	client, err := centreon.NewClient(
+		credBaseURL,
+		centreon.WithAPIToken("tok"), // a token makes the client issue the request directly (no login round trip)
+		centreon.WithHTTPClient(&http.Client{Transport: failRoundTripper{}}),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	log := testLogger(t)
+	ctx := t.Context()
+	req := &mcp.CallToolRequest{}
+
+	cases := []struct {
+		name string
+		run  func() (*mcp.CallToolResult, any, error)
+	}{
+		{"acknowledgement_get", func() (*mcp.CallToolResult, any, error) {
+			return acknowledgementGetHandler(client, log)(ctx, req, IDInput{ID: 1})
+		}},
+		{"downtime_get", func() (*mcp.CallToolResult, any, error) {
+			return downtimeGetHandler(client, log)(ctx, req, IDInput{ID: 1})
+		}},
+		{"monitoring_host_get", func() (*mcp.CallToolResult, any, error) {
+			return monitoringHostGetHandler(client, log)(ctx, req, IDInput{ID: 1})
+		}},
+		{"monitoring_resource_host_get", func() (*mcp.CallToolResult, any, error) {
+			return monitoringResourceHostGetHandler(client, log)(ctx, req, IDInput{ID: 1})
+		}},
+		{"notification_policy_host_get", func() (*mcp.CallToolResult, any, error) {
+			return notificationPolicyHostGetHandler(client, log)(ctx, req, HostIDInput{HostID: 1})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, _, err := tc.run()
+			if err != nil {
+				t.Fatalf("handler returned a Go error: %v", err)
+			}
+			if !res.IsError {
+				t.Fatal("expected an error result from the failing client")
+			}
+			assertNoCredential(t, textOf(t, res))
+		})
+	}
+}

--- a/tools/service_config_tools.go
+++ b/tools/service_config_tools.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterServiceConfigTools registers all service configuration tools.
@@ -196,8 +197,9 @@ func serviceCreateHandler(client *centreon.Client, logger *slog.Logger) func(ctx
 			Macros:            macros,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_service_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create service %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create service %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_create", "Created service with ID %d", id)
@@ -219,8 +221,9 @@ func serviceUpdateHandler(client *centreon.Client, logger *slog.Logger) func(ctx
 			IsActivated:         in.IsActivated,
 		}
 		if err := client.Services.Update(ctx, in.ID, &req); err != nil {
-			logger.Error("failed: centreon_service_update", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to update service %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_update", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to update service %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_update", "Updated service %d", in.ID)
@@ -233,8 +236,9 @@ func serviceDeleteHandler(client *centreon.Client, logger *slog.Logger) func(ctx
 		ctx = centreon.WithToolName(ctx, "centreon_service_delete")
 		logger.Info("centreon_service_delete", "id", in.ID)
 		if err := client.Services.Delete(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_service_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete service %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete service %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_delete", "Deleted service %d", in.ID)
@@ -257,8 +261,9 @@ func serviceGroupCreateHandler(client *centreon.Client, logger *slog.Logger) fun
 			Alias: in.Alias,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_service_group_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create service group %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_group_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create service group %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_group_create", "Created service group with ID %d", id)
@@ -271,8 +276,9 @@ func serviceGroupDeleteHandler(client *centreon.Client, logger *slog.Logger) fun
 		ctx = centreon.WithToolName(ctx, "centreon_service_group_delete")
 		logger.Info("centreon_service_group_delete", "id", in.ID)
 		if err := client.ServiceGroups.Delete(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_service_group_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete service group %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_group_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete service group %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_group_delete", "Deleted service group %d", in.ID)
@@ -295,8 +301,9 @@ func serviceCategoryCreateHandler(client *centreon.Client, logger *slog.Logger) 
 			Alias: in.Alias,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_service_category_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create service category %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_category_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create service category %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_category_create", "Created service category with ID %d", id)
@@ -309,8 +316,9 @@ func serviceCategoryDeleteHandler(client *centreon.Client, logger *slog.Logger) 
 		ctx = centreon.WithToolName(ctx, "centreon_service_category_delete")
 		logger.Info("centreon_service_category_delete", "id", in.ID)
 		if err := client.ServiceCategories.Delete(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_service_category_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete service category %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_category_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete service category %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_category_delete", "Deleted service category %d", in.ID)
@@ -338,8 +346,9 @@ func serviceSeverityCreateHandlerFn(
 			IconID: in.IconID,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_service_severity_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create service severity %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_severity_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create service severity %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_severity_create", "Created service severity with ID %d", id)
@@ -364,8 +373,9 @@ func serviceSeverityUpdateHandlerFn(
 			Level:  in.Level,
 			IconID: in.IconID,
 		}); err != nil {
-			logger.Error("failed: centreon_service_severity_update", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to update service severity %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_severity_update", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to update service severity %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_severity_update", "Updated service severity %d", in.ID)
@@ -385,8 +395,9 @@ func serviceSeverityDeleteHandlerFn(
 		ctx = centreon.WithToolName(ctx, "centreon_service_severity_delete")
 		logger.Info("centreon_service_severity_delete", "id", in.ID)
 		if err := fn(ctx, in.ID); err != nil {
-			logger.Error("failed: centreon_service_severity_delete", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to delete service severity %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_service_severity_delete", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to delete service severity %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_service_severity_delete", "Deleted service severity %d", in.ID)

--- a/tools/status_tools.go
+++ b/tools/status_tools.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -42,10 +43,16 @@ func RegisterStatusTools(s *mcp.Server, client *centreon.Client, logger *slog.Lo
 // It then returns the wrapped error for errgroup. Skipping cancelled reads keeps
 // one logical failure to one error line instead of three.
 func logReadError(logger *slog.Logger, part, msg string, err error) error {
+	// Classify once, up front, so the same credential-safe reason reaches both
+	// the log line and the errgroup error the client eventually sees (CWE-532;
+	// #63, #71). The cancellation check stays on the incoming err. The wrap
+	// deliberately drops %w: the raw chain is the leak vector and nothing
+	// downstream unwraps it (g.Wait's error is only printed via %v).
+	reason := redact.Reason(err)
 	if !errors.Is(err, context.Canceled) {
-		logger.Error("failed: centreon_platform_status ("+part+")", "error", err)
+		logger.Error("failed: centreon_platform_status ("+part+")", "error", reason)
 	}
-	return fmt.Errorf("%s: %w", msg, err)
+	return fmt.Errorf("%s: %s", msg, reason)
 }
 
 func platformStatusHandler(client *centreon.Client, logger *slog.Logger, host string) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
@@ -109,6 +116,10 @@ func platformStatusHandlerFn(
 			return nil
 		})
 		if err := g.Wait(); err != nil {
+			// err can only be a logReadError product, which already ran the
+			// upstream error through redact.Reason, so it carries no credential.
+			// Do not re-run redact.Reason here: that would reclassify the wrapped
+			// "failed to get ...: <reason>" string down to "request failed".
 			res, anyVal := errorResult("%v", err)
 			return res, anyVal, nil
 		}

--- a/tools/status_tools_test.go
+++ b/tools/status_tools_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -204,8 +205,47 @@ func TestPlatformStatusHandlerFn_ReportsError(t *testing.T) {
 			if strings.Contains(text, testStatusHost) {
 				t.Errorf("error result should not include the host, got: %q", text)
 			}
+			if strings.Contains(text, "boom") {
+				t.Errorf("error result should not echo the raw upstream error text, got: %q", text)
+			}
 		})
 	}
+}
+
+// TestPlatformStatusHandlerFn_ErrorNeverEchoesCredential pins #63 and #71 for
+// this tool: logReadError is the single choke point for the log line and the
+// errgroup error the client sees, so a client-call error carrying the base-URL
+// credential must be classified in both. The mis-parsed authority also carries
+// the mis-read host in the wrapped resolver error, so it exercises that case.
+// Deleting the redact.Reason call in logReadError turns this red.
+func TestPlatformStatusHandlerFn_ErrorNeverEchoesCredential(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	fetchHosts := func(context.Context) (*centreon.HostStatusCount, error) {
+		return nil, misparsedClientErr()
+	}
+	fetchServices := func(context.Context) (*centreon.ServiceStatusCount, error) {
+		return &centreon.ServiceStatusCount{}, nil
+	}
+	fetchServers := func(context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+		return &centreon.ListResponse[centreon.MonitoringServer]{}, nil
+	}
+
+	h := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, logger, testStatusHost)
+	res, _, err := h(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error result")
+	}
+	text := textOf(t, res)
+	assertNoCredential(t, text)
+	if !strings.Contains(text, "host status counts") || !strings.Contains(text, "DNS lookup failed") {
+		t.Errorf("want the failing read identified and the reason classified, got: %q", text)
+	}
+	assertNoCredential(t, buf.String())
 }
 
 // TestPlatformStatusHandlerFn_SuppressesCancellationLogs pins that a single

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 const (
@@ -226,8 +227,13 @@ func commonListHandler[T any](
 	opts := buildListOptions(in)
 	resp, err := requester(ctx, opts...)
 	if err != nil {
-		logger.Error("failed: "+toolName, "error", err)
-		res, anyVal := errorResult("failed: %s: %v", toolName, err)
+		// Classify the upstream error before it reaches the log or the client:
+		// it can be a *url.Error embedding the base-URL credential (CWE-532;
+		// #63, #71). This is the single sink shared by every list tool that
+		// routes through commonListHandler.
+		reason := redact.Reason(err)
+		logger.Error("failed: "+toolName, "error", reason)
+		res, anyVal := errorResult("failed: %s: %s", toolName, reason)
 		return res, anyVal, nil
 	}
 

--- a/tools/user_tools.go
+++ b/tools/user_tools.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	centreon "github.com/tphakala/centreon-go-client"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
 )
 
 // RegisterUserTools registers all user and contact tools.
@@ -77,8 +78,9 @@ func userUpdateHandler(client *centreon.Client, logger *slog.Logger) func(ctx co
 			Email: in.Email,
 		}
 		if err := client.Users.Update(ctx, in.ID, req); err != nil {
-			logger.Error("failed: centreon_user_update", "error", err, "id", in.ID)
-			res, anyVal := errorResult("failed to update user %d: %v", in.ID, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_user_update", "error", reason, "id", in.ID)
+			res, anyVal := errorResult("failed to update user %d: %s", in.ID, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_user_update", "Updated user %d", in.ID)
@@ -113,8 +115,9 @@ func userFilterCreateHandler(client *centreon.Client, logger *slog.Logger) func(
 			Criteria: in.Criteria,
 		})
 		if err != nil {
-			logger.Error("failed: centreon_user_filter_create", "error", err, "name", in.Name)
-			res, anyVal := errorResult("failed to create user filter %q: %v", in.Name, err)
+			reason := redact.Reason(err)
+			logger.Error("failed: centreon_user_filter_create", "error", reason, "name", in.Name)
+			res, anyVal := errorResult("failed to create user filter %q: %s", in.Name, reason)
 			return res, anyVal, nil
 		}
 		res, anyVal := successResult(logger, "centreon_user_filter_create", "Created user filter with ID %d", id)


### PR DESCRIPTION
Closes #63, #71, #67.

## Problem

A Centreon base URL can carry userinfo (`user:pass@host`), either from `CENTREON_HOST` or, in gateway mode, from a caller-supplied `X-Centreon-Host` header. When a request against it fails, the resulting error (net/http `*url.Error`, or a wrapped resolver, TLS, or upstream API error) embeds that credential in its text. Go`s `url.Error.Error` masks only what `url.Parse` decoded as userinfo, so a mis-parsed authority like `https://admin:1234/s3cr3tpw@host` (where `url.Parse` reads `admin` as the host and decodes no userinfo) prints the whole typed password, and even a well-formed URL leaks the username. Those errors reached the server log (#63) and the MCP client tool responses (#71), violating the #48 no-credential-to-client contract (CWE-532).

## Fix

A new fail-closed classifier, `internal/redact.Reason(err) string`, maps an error to a fixed compile-time description (`DNS lookup failed`, `centreon API error (HTTP 401)`, `cross-host redirect refused`, ...). Its hard invariant is that it never copies a string field out of the error chain: no `err.Error()`, no `url.Error.URL`, no `net.DNSError.Name`, no `APIError.Message`. Only compile-time strings and the trusted HTTP status integer are emitted, and an unrecognised error falls through to a constant, so a future error type nobody anticipated fails closed rather than leaking. This deliberately avoids a textual masker over free-form error prose, which is the pattern that produced the repeated `safeHost` masking-bypass fixes (#55/#57/#58/#62/#70).

`redact.Reason` is wired into every server-log sink (`server.go`) and every client-facing tool-response sink (`tools/*.go`). The client-side sweep covers all tool handlers, not only the two originally named in #71: a gateway caller presenting a token skips the startup login, so the first failure can land in any handler`s sink.

`noCrossHostRedirect` now wraps a `redact.ErrCrossHostRedirect` sentinel so the classifier recognises a refused redirect across the `*url.Error` that `http.Client` wraps it in.

## Scope and residual

The centreon-go-client`s own request logging (`client.go` `logError`) still prints the raw base URL; that is tracked upstream as tphakala/centreon-go-client#42 and is out of scope here. This PR fixes every sink this repo owns.

`CHANGELOG.md` is added (Keep a Changelog), backfilling the two prior breaking configuration changes (#28, #57/#58, #66) plus this security fix (#67).

## Verification

TDD throughout, and the classifier and its wiring are mutation-verified (each leak test was watched failing when redaction is reverted). New coverage: a `redact.Reason` table test (`internal/redact`, 100% statement coverage), per-sink leak tests for the log sinks (`server_redact_test.go`), the client sinks (`connection`, `platform_status`, `commonListHandler`), and a structural sweep test over representative own-sink handlers (`tools/redact_sweep_test.go`). `go build`, `go test ./...`, `go vet`, and `golangci-lint` are all clean.

Ran through the full pre-push gate (reuse, correctness, quality, integration, regression, test-quality agents plus a Gemini cross-check): no missed sink, classifier confirmed fail-closed, `%w`-drop in `logReadError` confirmed safe, no behavioral regression beyond the intended client-message change. Exhaustive per-handler leak coverage for the remaining copy-paste sinks is tracked as #73 (non-blocking; the shipped sweep is verified complete).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive credentials are no longer exposed in error messages or logs.
  * Errors are classified into safe, user-facing descriptions, including network, DNS, TLS, timeout, and API failures.
  * Unsafe redirects and invalid or insecure URLs are rejected by default.

* **Bug Fixes**
  * Improved error handling across authentication, connection checks, monitoring, configuration, operations, and status tools.
  * Added safeguards preventing credential leakage in failure responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->