### PR TITLE
fix: locate the credential boundary in every encoding, not only where it is raw (#68, #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `X-Centreon-Host` header in gateway mode) can no longer leak through an error
   value, including the mis-parsed-authority case where Go's own masking sees no
   userinfo to hide (CWE-532). (#63, #71)
-- Host-URL redaction in server logs no longer echoes a password when the userinfo
-  boundary is percent-encoded. Two shapes leaked: a `@` delimiter whose own hex
-  digits are encoded (`%25%34%30`), and a `:` separator written `%3A`, which Go
-  reads as part of a bare username so its own masking hides nothing. The encoded
-  `:` case is the more reachable of the two, since such a host passes startup
-  validation and runs normally (CWE-532). (#68, #75)
+- Host-URL redaction no longer echoes a password when the userinfo boundary is
+  percent-encoded, in server logs or in the configuration errors that quote a host.
+  Two shapes leaked: a `@` delimiter whose own hex digits are encoded
+  (`%25%34%30`), and a `:` separator written `%3A`, which Go reads as part of a
+  bare username so its own masking hides nothing. The encoded `:` case is the more
+  reachable of the two, since such a host passes startup validation and runs
+  normally. It leaked through four paths, including a bracketed-IPv6 carve-out and
+  a tail search that both looked for a raw `:` only (CWE-532). (#68, #75)
 
 ### Changed
 
@@ -37,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   read-only status and connection tools report the literal `(redacted host)`
   instead of a host name, because the authority cannot be identified without
   risking exposure of a credential. (#66)
+- A host URL whose credential boundary is only visible after percent-decoding is
+  now logged as `https://user:xxxxx`, or `https://xxxxx` when even the username
+  boundary is unreadable, instead of being logged verbatim. The host name is lost
+  in those cases because its position cannot be trusted. A URL carrying only one
+  half of a credential shape, such as an encoded `@` in a path with no `:`, is
+  still logged unchanged. (#68, #75)
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `X-Centreon-Host` header in gateway mode) can no longer leak through an error
   value, including the mis-parsed-authority case where Go's own masking sees no
   userinfo to hide (CWE-532). (#63, #71)
+- Host-URL redaction in server logs no longer echoes a password when the userinfo
+  boundary is percent-encoded. Two shapes leaked: a `@` delimiter whose own hex
+  digits are encoded (`%25%34%30`), and a `:` separator written `%3A`, which Go
+  reads as part of a bare username so its own masking hides nothing. The encoded
+  `:` case is the more reachable of the two, since such a host passes startup
+  validation and runs normally (CWE-532). (#68, #75)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now logged as `https://user:xxxxx`, or `https://xxxxx` when even the username
   boundary is unreadable, instead of being logged verbatim. The host name is lost
   in those cases because its position cannot be trusted. A URL carrying only one
-  half of a credential shape, such as an encoded `@` in a path with no `:`, is
-  still logged unchanged. (#68, #75)
+  half of a credential shape is still logged unchanged, so an encoded `@` in the
+  path of a portless host does not trigger it; note a port supplies the missing
+  `:`, so the same path behind `host:8443` is masked to `https://host:xxxxx`.
+  Configuration errors that quote a rejected host now name the parse failure
+  ("invalid port after host") instead of quoting the offending span, which is what
+  reprinted the credential; the masked host is still quoted alongside. (#68, #75)
 
 ## [1.0.0]
 

--- a/config.go
+++ b/config.go
@@ -681,12 +681,10 @@ func maskAuthorityPassword(host string) string {
 // that reached it carrying one, echoing the userinfo in front. It was caught in
 // review and never shipped, but it is the reason the guard is spelled out here.
 func maskAmbiguousAuthority(prefix, rest string) string {
-	// rest spans the whole authority, so the first colon userinfoColon finds is only
-	// a username boundary when no credential delimiter precedes it. Past a delimiter
-	// it is the PORT colon, and masking there would return the userinfo verbatim.
-	// That is not hypothetical: on the issue #75 path the caller has already
-	// established the userinfo holds no raw ':', so every raw colon in rest sits
-	// after the '@' and this guard is what makes the branch fail closed at all.
+	// rest spans the whole authority, so the first colon found in it is only a
+	// username boundary when no credential delimiter precedes it. Past a delimiter it
+	// is the PORT colon, and masking there would return the userinfo verbatim.
+	//
 	// The span kept as the username has to be innocent on two counts. No credential
 	// delimiter may precede the colon, or the colon belongs to a port rather than to
 	// a boundary. And the searched region may hold no separator of its own under an
@@ -824,23 +822,6 @@ func unhexDigit(c byte) byte {
 	}
 }
 
-// userinfoColon returns the index of the ':' that starts the password span, or -1.
-// A leading bracketed IPv6 literal is skipped so its own colons are not mistaken
-// for the delimiter, which would otherwise mask from inside the address and leave
-// a truncated "[" where the host should be. The literal must parse as an IP, so a
-// bracket-prefixed username such as "[user:secret" still masks at its real colon.
-func userinfoColon(userinfo string) int {
-	from, ok := userinfoSearchStart(userinfo)
-	if !ok {
-		return -1
-	}
-	colon := strings.IndexByte(userinfo[from:], ':')
-	if colon < 0 {
-		return -1
-	}
-	return from + colon
-}
-
 // userinfoSearchStart returns the offset in userinfo at which a username/password
 // separator may legitimately begin, skipping a leading bracketed IP literal whose
 // own colons belong to the address rather than to a credential. ok is false when
@@ -851,8 +832,9 @@ func userinfoColon(userinfo string) int {
 // the whole userinfo instead reads a bracketed literal's own colons as a separator,
 // so a userinfo that IS such a literal ("https://[::1]@host") gets masked away for
 // nothing; searching past the raw colon instead reports a port or tail colon and
-// leaves the real credential standing in front of the mask. An ordinary bracketed
-// HOST is not affected either way, since it never reaches here as userinfo.
+// leaves the real credential standing in front of the mask. The skip is
+// load-bearing in both callers: "https://[::1]/p:pw%25%34%30host" masks to
+// "https://[::1]/p:xxxxx" with it and to "https://[:xxxxx" without.
 func userinfoSearchStart(userinfo string) (from int, ok bool) {
 	if !strings.HasPrefix(userinfo, "[") {
 		return 0, true

--- a/config.go
+++ b/config.go
@@ -304,11 +304,13 @@ func validateHostScheme(host string, allowHTTP bool) error {
 // That rule is not an absolute, and the exceptions are the interesting part. A
 // credential needs BOTH a delimiter and a separator, so an input carrying only one
 // of them is left intact: "https://host/path/%25%34%30" decodes to a '@' and hides
-// nothing. The username is kept whenever a raw colon marks where the password
-// starts, so the common fail-closed output is "https://admin:xxxxx" rather than
-// "https://xxxxx". And the bounded decode fails closed on exhaustion, so an
-// ordinary path nested deeper than maxDecodeRounds is treated as ambiguous rather
-// than as proof of anything.
+// nothing. The username is kept when a raw colon marks where the password starts,
+// giving "https://admin:xxxxx" instead of "https://xxxxx"; that is the usual shape
+// for issue #68, while issue #75 mostly loses the username too, since an encoded
+// separator is exactly the case where no raw colon marks the boundary. And the
+// bounded decode reports exhaustion as uncertainty rather
+// than as a finding, so an ordinary path nested deeper than maxDecodeRounds is left
+// alone unless something else in the input actually looks like a credential.
 func safeHost(host string) string {
 	if u, err := url.Parse(host); err == nil {
 		if u.User != nil {
@@ -377,18 +379,23 @@ func redactedCoversCredential(u *url.URL, host string) bool {
 	if tailCarriesAtSign(afterAuthorityDelimiter(host)) {
 		return false
 	}
-	if _, hasPassword := u.User.Password(); hasPassword {
-		return true
-	}
-	// Go splits userinfo on a RAW ':' only, so an encoded separator ("%3A") leaves
-	// the whole span as the username with no password, and url.Redacted then masks
-	// nothing while a password is plainly present (issue #75). Username() returns the
-	// decoded span, so a ':' in it is exactly that case. Counting a single '@' below
-	// cannot be trusted to mean "a bare username with nothing to hide" until this is
-	// ruled out: that fallback is an exemption, and an exemption that checks less
-	// than the whole span it exempts is a leak (the lesson of issue #62).
+	// Go splits userinfo on a RAW ':' only, so an encoded separator ("%3A") is not a
+	// boundary to it (issue #75). Username() returns the decoded span, so a ':' in it
+	// is exactly that case, and it must be ruled out BEFORE either check below.
+	//
+	// Ahead of hasPassword, because an encoded separator EARLIER than the raw one Go
+	// split on means the real password starts sooner: url.Redacted then masks only
+	// the fragment after the raw ':' and echoes the rest. "admin%3Apw:x@host" masked
+	// to "admin%3Apw:xxxxx@host" and published the password.
+	//
+	// Ahead of the '@' count, because that fallback is an exemption concluding "a
+	// bare username with nothing to hide", and an exemption that checks less than
+	// the whole span it exempts is a leak (the lesson of issue #62).
 	if decodesToContain(u.User.Username(), ':') {
 		return false
+	}
+	if _, hasPassword := u.User.Password(); hasPassword {
+		return true
 	}
 	return strings.Count(host, "@") == 1
 }
@@ -670,7 +677,9 @@ func maskAuthorityPassword(host string) string {
 // "Identifies one" is the load-bearing phrase. rest spans the whole authority, so a
 // raw colon found past the credential delimiter is a port or an IPv6 literal's own
 // colon, and masking from there returns the userinfo, and the credential, verbatim.
-// That shipped once: it masked the port of every host written with one.
+// A first attempt at this function got that wrong and masked the port of any host
+// that reached it carrying one, echoing the userinfo in front. It was caught in
+// review and never shipped, but it is the reason the guard is spelled out here.
 func maskAmbiguousAuthority(prefix, rest string) string {
 	// rest spans the whole authority, so the first colon userinfoColon finds is only
 	// a username boundary when no credential delimiter precedes it. Past a delimiter
@@ -678,10 +687,28 @@ func maskAmbiguousAuthority(prefix, rest string) string {
 	// That is not hypothetical: on the issue #75 path the caller has already
 	// established the userinfo holds no raw ':', so every raw colon in rest sits
 	// after the '@' and this guard is what makes the branch fail closed at all.
-	if colon := userinfoColon(rest); colon >= 0 && !decodesToContain(rest[:colon], '@') {
-		return prefix + rest[:colon] + ":xxxxx"
+	// The span kept as the username has to be innocent on two counts. No credential
+	// delimiter may precede the colon, or the colon belongs to a port rather than to
+	// a boundary. And the searched region may hold no separator of its own under an
+	// encoding, or the span IS the credential: in "admin%3Apw:x@host" everything
+	// before the raw ':' is the real user and password.
+	//
+	// The second check covers rest[from:colon], not rest[:colon], because a bracketed
+	// literal skipped by the search carries its own raw colons and they are part of
+	// an address, not a boundary.
+	from, ok := userinfoSearchStart(rest)
+	if !ok {
+		return prefix + "xxxxx"
 	}
-	return prefix + "xxxxx"
+	colon := strings.IndexByte(rest[from:], ':')
+	if colon < 0 {
+		return prefix + "xxxxx"
+	}
+	colon += from
+	if decodesToContain(rest[:colon], '@') || decodesToContain(rest[from:colon], ':') {
+		return prefix + "xxxxx"
+	}
+	return prefix + rest[:colon] + ":xxxxx"
 }
 
 // maxDecodeRounds bounds how many rounds of percent-decoding decodesToContain
@@ -821,9 +848,11 @@ func userinfoColon(userinfo string) int {
 //
 // It exists as a separate function because the encoded-separator search (issue #75)
 // has to cover EXACTLY the span this offset opens, no more and no less. Searching
-// the whole userinfo instead reports the address's own colons and over-masks every
-// bracketed host; searching past the raw colon instead reports a port or tail colon
-// and leaves the real credential standing in front of the mask.
+// the whole userinfo instead reads a bracketed literal's own colons as a separator,
+// so a userinfo that IS such a literal ("https://[::1]@host") gets masked away for
+// nothing; searching past the raw colon instead reports a port or tail colon and
+// leaves the real credential standing in front of the mask. An ordinary bracketed
+// HOST is not affected either way, since it never reaches here as userinfo.
 func userinfoSearchStart(userinfo string) (from int, ok bool) {
 	if !strings.HasPrefix(userinfo, "[") {
 		return 0, true

--- a/config.go
+++ b/config.go
@@ -273,6 +273,11 @@ func validateHostScheme(host string, allowHTTP bool) error {
 // with no password at all, and safeHost never masks a username. A "//" anywhere
 // else in the password, including the realistic base64 case, is handled. RFC 3986
 // requires percent-encoding these characters in userinfo.
+//
+// Where a credential is present but its boundary is only visible after decoding,
+// safeHost fails closed and drops the host rather than echo the input: a delimiter
+// whose hex digits are encoded (issue #68) and an encoded ':' separator, which Go
+// reads as a bare username so url.Redacted masks nothing (issue #75).
 func safeHost(host string) string {
 	if u, err := url.Parse(host); err == nil {
 		if u.User != nil {
@@ -296,19 +301,37 @@ func safeHost(host string) string {
 			return host
 		}
 	}
-	// The scheme-less user:pass@host form parses as scheme:opaque, so reparse it as
-	// an authority. Only the single-'@' form with no further at sign after the
-	// delimiter is unambiguous enough to trust: a second '@' (raw, or percent-encoded
-	// as %40 in the tail) means the reparse would invent an authority out of
-	// "scheme:user" or mask the wrong span and leave the real password in place, so
-	// those fall through to the textual masker instead (issues #55, #62).
-	if strings.Count(host, "@") == 1 {
-		if u, err := url.Parse("//" + host); err == nil && u.User != nil &&
-			!tailCarriesAtSign(afterAuthorityDelimiter(host)) {
-			return strings.TrimPrefix(u.Redacted(), "//")
-		}
+	// The scheme-less user:pass@host form parses as scheme:opaque, so it needs a
+	// reparse; anything the reparse cannot read unambiguously falls through to the
+	// textual masker below.
+	if masked, ok := reparsedAuthority(host); ok {
+		return masked
 	}
 	return maskAuthorityPassword(host)
+}
+
+// reparsedAuthority masks the scheme-less user:pass@host form, which url.Parse
+// reads as scheme:opaque and so exposes no userinfo to mask. It reports false when
+// the form is too ambiguous to trust, leaving the caller on the textual masker.
+//
+// Only the single-'@' form with no further at sign after the delimiter is
+// unambiguous enough: a second '@' (raw, or percent-encoded as %40 in the tail)
+// means the reparse would invent an authority out of "scheme:user" or mask the
+// wrong span and leave the real password in place (issues #55, #62). The
+// encoded-separator check is the one redactedCoversCredential makes, for the same
+// reason: this hands the string to url.Redacted, which masks nothing when Go read
+// the userinfo as a bare username because its ':' was percent-encoded (issue #75).
+func reparsedAuthority(host string) (string, bool) {
+	if strings.Count(host, "@") != 1 {
+		return "", false
+	}
+	u, err := url.Parse("//" + host)
+	if err != nil || u.User == nil ||
+		tailCarriesAtSign(afterAuthorityDelimiter(host)) ||
+		decodesToContain(u.User.Username(), ':') {
+		return "", false
+	}
+	return strings.TrimPrefix(u.Redacted(), "//"), true
 }
 
 // redactedCoversCredential reports whether url.Redacted masks the whole credential
@@ -325,6 +348,16 @@ func redactedCoversCredential(u *url.URL, host string) bool {
 	}
 	if _, hasPassword := u.User.Password(); hasPassword {
 		return true
+	}
+	// Go splits userinfo on a RAW ':' only, so an encoded separator ("%3A") leaves
+	// the whole span as the username with no password, and url.Redacted then masks
+	// nothing while a password is plainly present (issue #75). Username() returns the
+	// decoded span, so a ':' in it is exactly that case. Counting a single '@' below
+	// cannot be trusted to mean "a bare username with nothing to hide" until this is
+	// ruled out: that fallback is an exemption, and an exemption that checks less
+	// than the whole span it exempts is a leak (the lesson of issue #62).
+	if decodesToContain(u.User.Username(), ':') {
+		return false
 	}
 	return strings.Count(host, "@") == 1
 }
@@ -508,24 +541,157 @@ func tailCarriesAtSign(tail string) bool {
 // path, query or fragment (issue #55). It masks the span from the first ':' after
 // the authority marker to the delimiter '@', found by lastAtDelimiter so a
 // percent-encoded delimiter (%40) is located too (issue #62). A string with no
-// delimiter, or with no ':' before it, has no password span and is returned
-// unchanged. The encoded delimiter is kept verbatim in the output, so the host
-// after it still greps.
+// delimiter, or with no ':' before it in any encoding, has no password span and is
+// returned unchanged. The encoded delimiter is kept verbatim in the output, so the
+// host after it still greps.
+//
+// Two shapes cannot be masked in place and fail closed through
+// maskAmbiguousAuthority instead, losing the host: a delimiter whose hex digits are
+// themselves encoded (issue #68), and a userinfo whose ':' separator is encoded
+// (issue #75). Both are locatable only after decoding, and mapping a decoded offset
+// back through every round is not worth the complexity for inputs that
+// validateHostScheme already rejects outright.
 func maskAuthorityPassword(host string) string {
 	rest, prefix := host, ""
 	if k := authorityMarker(rest); k >= 0 {
 		prefix, rest = rest[:k], rest[k:]
 	}
 	at := lastAtDelimiter(rest)
+	// lastAtDelimiter sees a raw '@' and the flat %(25)*40 shape. It cannot see a
+	// delimiter whose own hex digits are encoded ("%25%34%30" decodes to "%40" and
+	// then to '@'), and such a delimiter can sit AFTER the one it did find, leaving
+	// the span between them standing as password material (issue #68). Pinning that
+	// position in the original bytes would mean mapping an offset back through every
+	// decode round, so mask from the userinfo colon instead and lose the host. That
+	// is the issue #61 trade this function already makes elsewhere, and the shapes
+	// that reach here are rejected by validateHostScheme, so in env mode they cannot
+	// occur at all; only a caller-supplied X-Centreon-Host header produces them.
+	span := rest
+	if at >= 0 {
+		span = rest[at+1:]
+	}
+	if decodesToContain(span, '@') {
+		return maskAmbiguousAuthority(prefix, rest)
+	}
 	if at < 0 {
 		return host // no userinfo
 	}
 	userinfo := rest[:at]
 	colon := userinfoColon(userinfo)
 	if colon < 0 {
+		// No raw ':' separates a username from a password here, but the separator can
+		// itself be percent-encoded ("%3A"), in which case there IS a password span
+		// and returning the input would echo it (issue #75). Only a userinfo carrying
+		// no raw ':' at all is re-examined, so the bracketed-IPv6 readings above,
+		// which deliberately return -1 with raw colons present, keep their behaviour.
+		if !strings.ContainsRune(userinfo, ':') && decodesToContain(userinfo, ':') {
+			return maskAmbiguousAuthority(prefix, rest)
+		}
 		return host // no ':' before the delimiter, so there is no password span
 	}
 	return prefix + userinfo[:colon] + ":xxxxx" + rest[at:]
+}
+
+// maskAmbiguousAuthority masks from the password span to the end of the input, for
+// the case where a credential is present but its delimiter cannot be located in the
+// original bytes. A username is not a secret and keeps the line greppable, so it is
+// preserved when a raw colon identifies one; when even the colon is visible only
+// after decoding, there is no trustworthy boundary and the whole authority goes.
+func maskAmbiguousAuthority(prefix, rest string) string {
+	if colon := userinfoColon(rest); colon >= 0 {
+		return prefix + rest[:colon] + ":xxxxx"
+	}
+	return prefix + "xxxxx"
+}
+
+// maxDecodeRounds bounds how many rounds of percent-decoding decodesToContain
+// follows before giving up. It matches the bound in tailCarriesAtSign so the
+// routing guards and the textual masker agree on how deep a delimiter may hide
+// before an input is treated as ambiguous.
+const maxDecodeRounds = 4
+
+// decodesToContain reports whether s decodes to a string containing target within
+// maxDecodeRounds rounds of decodeLenient. It fails closed, returning true, when
+// the rounds run out while decoding is still making progress, because target could
+// be hiding under another layer. Decoding that stops making progress is complete,
+// so a string whose remaining escapes are undecodable (a "%zz" typo in a path) is
+// answered from its decoded form rather than being treated as suspicious.
+//
+// Allocation is bounded at maxDecodeRounds strings of at most len(s) bytes each,
+// independent of how deeply the input nests. Peeling one layer per candidate
+// position instead was measured at 1.15GB per call on a 64KB nested input, so the
+// bound is deliberately on rounds rather than on layers (issue #62).
+func decodesToContain(s string, target byte) bool {
+	for range maxDecodeRounds {
+		if strings.IndexByte(s, target) >= 0 {
+			return true
+		}
+		next := decodeLenient(s)
+		if next == s {
+			return false // decoding is complete and target never appeared
+		}
+		s = next
+	}
+	return true
+}
+
+// decodeLenient applies one round of percent-decoding to s. An escape that is not
+// '%' followed by two hex digits is left as a literal '%' and scanning continues
+// past it. url.PathUnescape cannot serve here because it rejects the whole string
+// on the first bad escape, which would let a "%zz" typo anywhere in a URL hide a
+// credential delimiter elsewhere in it. s is returned unchanged, without
+// allocating, when it holds nothing decodable.
+func decodeLenient(s string) string {
+	if !hasDecodableEscape(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if isEscapeAt(s, i) {
+			b.WriteByte(unhexDigit(s[i+1])<<4 | unhexDigit(s[i+2]))
+			i += 3
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// hasDecodableEscape reports whether s holds at least one '%' followed by two hex
+// digits, which is what decodeLenient would rewrite.
+func hasDecodableEscape(s string) bool {
+	for i := range len(s) {
+		if isEscapeAt(s, i) {
+			return true
+		}
+	}
+	return false
+}
+
+// isEscapeAt reports whether a well-formed percent-escape starts at s[i].
+func isEscapeAt(s string, i int) bool {
+	return s[i] == '%' && i+2 < len(s) && isHexDigit(s[i+1]) && isHexDigit(s[i+2])
+}
+
+func isHexDigit(c byte) bool {
+	return c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
+}
+
+// decimalDigits is how many digit characters precede 'a' and 'A' in the hex
+// alphabet, so a letter's value is its distance from that letter plus this.
+const decimalDigits = 10
+
+func unhexDigit(c byte) byte {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0'
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + decimalDigits
+	default:
+		return c - 'A' + decimalDigits
+	}
 }
 
 // userinfoColon returns the index of the ':' that starts the password span, or -1.
@@ -572,6 +738,12 @@ func userinfoColon(userinfo string) int {
 // dangerous case a raw search misses (the hybrid "admin:p@ssword%40host", issue
 // #62). Escapes that do not provably decode to '@' (a malformed "%zz", or "%4c" for
 // 'L') are not delimiters, so an ordinary encoded path is left intact.
+//
+// This scan is deliberately incomplete. It recognises only the shape whose hex
+// digits stay literal, because that one can be matched in place, allocation-free,
+// at any depth. A delimiter whose digits are themselves encoded ("%25%34%30",
+// issue #68) is invisible here; callers pair this with decodesToContain, which
+// answers whether such a delimiter exists but not where, and so fails closed.
 func lastAtDelimiter(s string) int {
 	at := strings.LastIndexByte(s, '@')
 	for i := len(s) - 1; i > at; i-- {

--- a/config.go
+++ b/config.go
@@ -213,17 +213,39 @@ func gatewayMode(cfg *Config) bool {
 // that shape is indistinguishable from a mis-encoded credential, so redaction in
 // the log and the fail-closed placeholder in displayHost are the controls there,
 // not validation (issue #55).
+// urlParseReason maps a url.Parse failure to a fixed description of what was wrong.
+// It never copies a string out of the error, because Go's parse reasons quote the
+// offending span of the input, which for a host URL is the credential. The returned
+// value is always one of the constants below, so no input can reach a log through
+// it. This is the same fail-closed philosophy as internal/redact.Reason, which does
+// the job for client-call errors, applied to the one parse error that predates it.
+func urlParseReason(err error) string {
+	reason := err
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
+		reason = urlErr.Err
+	}
+	switch text := reason.Error(); {
+	case strings.HasPrefix(text, "invalid port "):
+		return "invalid port after host"
+	case strings.HasPrefix(text, "invalid URL escape "):
+		return "invalid percent-escape"
+	case strings.HasPrefix(text, "invalid character "):
+		return "invalid character in host name"
+	default:
+		return "malformed URL"
+	}
+}
+
 func validateHostScheme(host string, allowHTTP bool) error {
 	u, err := url.Parse(host)
 	if err != nil {
 		// url.Error.Error() embeds the URL it failed on, so wrapping err directly
 		// would reprint the raw credential that safeHost just masked in the same
-		// message (CWE-532). Wrap only the reason.
-		reason := err
-		if urlErr, ok := errors.AsType[*url.Error](err); ok {
-			reason = urlErr.Err
-		}
-		return fmt.Errorf("invalid host url %q: %w", safeHost(host), reason)
+		// message (CWE-532). Unwrapping one layer is not enough: Go's own reason for
+		// a mis-parsed authority is `invalid port ":<password>" after host`, which
+		// quotes the credential too, so the masked host and the password shipped in
+		// the same log line. Classify instead of quoting.
+		return fmt.Errorf("invalid host url %q: %s", safeHost(host), urlParseReason(err))
 	}
 	switch u.Scheme {
 	case schemeHTTPS, schemeHTTP:
@@ -278,6 +300,15 @@ func validateHostScheme(host string, allowHTTP bool) error {
 // safeHost fails closed and drops the host rather than echo the input: a delimiter
 // whose hex digits are encoded (issue #68) and an encoded ':' separator, which Go
 // reads as a bare username so url.Redacted masks nothing (issue #75).
+//
+// That rule is not an absolute, and the exceptions are the interesting part. A
+// credential needs BOTH a delimiter and a separator, so an input carrying only one
+// of them is left intact: "https://host/path/%25%34%30" decodes to a '@' and hides
+// nothing. The username is kept whenever a raw colon marks where the password
+// starts, so the common fail-closed output is "https://admin:xxxxx" rather than
+// "https://xxxxx". And the bounded decode fails closed on exhaustion, so an
+// ordinary path nested deeper than maxDecodeRounds is treated as ambiguous rather
+// than as proof of anything.
 func safeHost(host string) string {
 	if u, err := url.Parse(host); err == nil {
 		if u.User != nil {
@@ -445,7 +476,18 @@ func isURLScheme(s string) bool {
 func tailCarriesPassword(host string) bool {
 	tail := authorityTail(host)
 	at := lastAtDelimiter(tail)
-	return at >= 0 && strings.IndexByte(tail[:at], ':') >= 0
+	if at < 0 {
+		// lastAtDelimiter cannot see a delimiter whose hex digits are encoded, so the
+		// bracketed-authority carve-out above used to return such an input verbatim
+		// (issue #68). The position is unknown here, so ask only whether a separator
+		// is positively present anywhere in the tail.
+		sep, _ := decodesToTarget(tail, ':')
+		return decodesToContain(tail, '@') && sep
+	}
+	// The separator is sought in every encoding, not just raw. A raw IndexByte here
+	// let the same carve-out return an input verbatim whenever the tail's ':' was
+	// written "%3A", the hazard the masker itself was fixed for (issue #75).
+	return decodesToContain(tail[:at], ':')
 }
 
 // redactedHostPlaceholder is the fail-closed display value for a host whose
@@ -519,7 +561,11 @@ func displayHost(host string) string {
 // Note "%4c" is a valid escape for 'L', so a tail like "/pw%4chost" holds no
 // delimiter in any encoding and is trusted too.
 func tailCarriesAtSign(tail string) bool {
-	for range 4 {
+	// Shares maxDecodeRounds with decodesToContain so the routing guards and the
+	// textual masker agree on how deep a delimiter may hide. The bound used to be a
+	// bare literal here while the constant's doc claimed they matched, which nothing
+	// enforced: changing one silently desynchronised the two.
+	for range maxDecodeRounds {
 		if strings.ContainsRune(tail, '@') {
 			return true
 		}
@@ -546,11 +592,14 @@ func tailCarriesAtSign(tail string) bool {
 // host after it still greps.
 //
 // Two shapes cannot be masked in place and fail closed through
-// maskAmbiguousAuthority instead, losing the host: a delimiter whose hex digits are
-// themselves encoded (issue #68), and a userinfo whose ':' separator is encoded
-// (issue #75). Both are locatable only after decoding, and mapping a decoded offset
-// back through every round is not worth the complexity for inputs that
-// validateHostScheme already rejects outright.
+// maskAmbiguousAuthority instead: a delimiter whose hex digits are themselves
+// encoded (issue #68), and a userinfo whose ':' separator is encoded (issue #75).
+// Both are locatable only after decoding, and mapping a decoded offset back through
+// every round is not worth the complexity, so the position is given up rather than
+// reconstructed. Note the two differ in reachability: validateHostScheme rejects
+// the #68 shapes outright, so in env mode only a caller-supplied X-Centreon-Host
+// header produces them, while it ACCEPTS "https://admin%3Apw@host", which therefore
+// runs normally and reaches a log on every line.
 func maskAuthorityPassword(host string) string {
 	rest, prefix := host, ""
 	if k := authorityMarker(rest); k >= 0 {
@@ -560,36 +609,56 @@ func maskAuthorityPassword(host string) string {
 	// lastAtDelimiter sees a raw '@' and the flat %(25)*40 shape. It cannot see a
 	// delimiter whose own hex digits are encoded ("%25%34%30" decodes to "%40" and
 	// then to '@'), and such a delimiter can sit AFTER the one it did find, leaving
-	// the span between them standing as password material (issue #68). Pinning that
-	// position in the original bytes would mean mapping an offset back through every
-	// decode round, so mask from the userinfo colon instead and lose the host. That
-	// is the issue #61 trade this function already makes elsewhere, and the shapes
-	// that reach here are rejected by validateHostScheme, so in env mode they cannot
-	// occur at all; only a caller-supplied X-Centreon-Host header produces them.
-	span := rest
+	// the span between them standing as password material (issue #68). Its position
+	// is only recoverable by mapping an offset back through every decode round, so
+	// this fails closed instead and masks from the userinfo separator.
+	//
+	// A delimiter alone is not a credential. Requiring a separator too is what keeps
+	// an ordinary URL intact: "https://host/path/%25%34%30" decodes to a '@' and
+	// holds no secret, and decodesToContain deliberately fails closed once its round
+	// bound runs out, which "https://host/100%25252525" reaches with no '@' at all.
+	// Masking either of those would drop a hostname an operator needs, to hide
+	// nothing.
+	deeper := rest
 	if at >= 0 {
-		span = rest[at+1:]
+		deeper = rest[at+1:]
 	}
-	if decodesToContain(span, '@') {
+	if decodesToContain(deeper, '@') {
+		// The separator must be positively found, not merely possible: ambiguity is
+		// not evidence, and the two searches exhaust the round bound together on a
+		// deeply nested path that holds neither character.
+		if sep, _ := decodesToTarget(rest, ':'); !sep {
+			return host // a delimiter but no separator, so no password span
+		}
 		return maskAmbiguousAuthority(prefix, rest)
 	}
 	if at < 0 {
 		return host // no userinfo
 	}
+	// The separator can itself be percent-encoded ("%3A"), in which case Go parsed a
+	// bare username and url.Redacted masked nothing (issue #75). Search for it over
+	// EXACTLY the span the raw search covers: past a leading bracketed IP literal,
+	// whose own colons belong to the address, and ahead of the first raw colon,
+	// because a colon after it is a port or tail colon and masking there would leave
+	// the real credential standing in front of the mask.
 	userinfo := rest[:at]
-	colon := userinfoColon(userinfo)
+	from, ok := userinfoSearchStart(userinfo)
+	if !ok {
+		return host // the userinfo is a bare bracketed IP literal, so no password span
+	}
+	searched := userinfo[from:]
+	colon := strings.IndexByte(searched, ':')
+	encoded := searched
+	if colon >= 0 {
+		encoded = searched[:colon]
+	}
+	if decodesToContain(encoded, ':') {
+		return maskAmbiguousAuthority(prefix, rest)
+	}
 	if colon < 0 {
-		// No raw ':' separates a username from a password here, but the separator can
-		// itself be percent-encoded ("%3A"), in which case there IS a password span
-		// and returning the input would echo it (issue #75). Only a userinfo carrying
-		// no raw ':' at all is re-examined, so the bracketed-IPv6 readings above,
-		// which deliberately return -1 with raw colons present, keep their behaviour.
-		if !strings.ContainsRune(userinfo, ':') && decodesToContain(userinfo, ':') {
-			return maskAmbiguousAuthority(prefix, rest)
-		}
 		return host // no ':' before the delimiter, so there is no password span
 	}
-	return prefix + userinfo[:colon] + ":xxxxx" + rest[at:]
+	return prefix + userinfo[:from+colon] + ":xxxxx" + rest[at:]
 }
 
 // maskAmbiguousAuthority masks from the password span to the end of the input, for
@@ -597,8 +666,19 @@ func maskAuthorityPassword(host string) string {
 // original bytes. A username is not a secret and keeps the line greppable, so it is
 // preserved when a raw colon identifies one; when even the colon is visible only
 // after decoding, there is no trustworthy boundary and the whole authority goes.
+//
+// "Identifies one" is the load-bearing phrase. rest spans the whole authority, so a
+// raw colon found past the credential delimiter is a port or an IPv6 literal's own
+// colon, and masking from there returns the userinfo, and the credential, verbatim.
+// That shipped once: it masked the port of every host written with one.
 func maskAmbiguousAuthority(prefix, rest string) string {
-	if colon := userinfoColon(rest); colon >= 0 {
+	// rest spans the whole authority, so the first colon userinfoColon finds is only
+	// a username boundary when no credential delimiter precedes it. Past a delimiter
+	// it is the PORT colon, and masking there would return the userinfo verbatim.
+	// That is not hypothetical: on the issue #75 path the caller has already
+	// established the userinfo holds no raw ':', so every raw colon in rest sits
+	// after the '@' and this guard is what makes the branch fail closed at all.
+	if colon := userinfoColon(rest); colon >= 0 && !decodesToContain(rest[:colon], '@') {
 		return prefix + rest[:colon] + ":xxxxx"
 	}
 	return prefix + "xxxxx"
@@ -622,17 +702,31 @@ const maxDecodeRounds = 4
 // position instead was measured at 1.15GB per call on a 64KB nested input, so the
 // bound is deliberately on rounds rather than on layers (issue #62).
 func decodesToContain(s string, target byte) bool {
+	found, ambiguous := decodesToTarget(s, target)
+	return found || ambiguous
+}
+
+// decodesToTarget is decodesToContain with its two reasons kept apart: found means
+// target actually appeared within the bound, ambiguous means the rounds ran out
+// while decoding was still making progress, so target could be hiding deeper.
+//
+// The distinction matters wherever ambiguity alone must not drive a decision. A
+// credential needs both a delimiter and a separator, and a deeply nested but
+// perfectly ordinary path ("/100%25252525") exhausts the bound on BOTH searches at
+// once, so treating ambiguity as evidence for each of them in turn would destroy
+// the hostname to hide nothing.
+func decodesToTarget(s string, target byte) (found, ambiguous bool) {
 	for range maxDecodeRounds {
 		if strings.IndexByte(s, target) >= 0 {
-			return true
+			return true, false
 		}
 		next := decodeLenient(s)
 		if next == s {
-			return false // decoding is complete and target never appeared
+			return false, false // decoding is complete and target never appeared
 		}
 		s = next
 	}
-	return true
+	return false, true
 }
 
 // decodeLenient applies one round of percent-decoding to s. An escape that is not
@@ -641,33 +735,42 @@ func decodesToContain(s string, target byte) bool {
 // on the first bad escape, which would let a "%zz" typo anywhere in a URL hide a
 // credential delimiter elsewhere in it. s is returned unchanged, without
 // allocating, when it holds nothing decodable.
+// Literal runs between escapes are copied whole rather than a byte at a time, and
+// decoding starts at the first escape rather than rescanning the prefix the search
+// already walked. In gateway mode the input is a caller-supplied header, so this is
+// the difference between copying at memmove speed and at one call per byte on an
+// input an attacker chooses the length of.
 func decodeLenient(s string) string {
-	if !hasDecodableEscape(s) {
+	first := firstEscape(s)
+	if first < 0 {
 		return s
 	}
 	var b strings.Builder
 	b.Grow(len(s))
-	for i := 0; i < len(s); {
+	run := 0
+	for i := first; i < len(s); {
 		if isEscapeAt(s, i) {
+			b.WriteString(s[run:i])
 			b.WriteByte(unhexDigit(s[i+1])<<4 | unhexDigit(s[i+2]))
 			i += 3
+			run = i
 			continue
 		}
-		b.WriteByte(s[i])
 		i++
 	}
+	b.WriteString(s[run:])
 	return b.String()
 }
 
-// hasDecodableEscape reports whether s holds at least one '%' followed by two hex
-// digits, which is what decodeLenient would rewrite.
-func hasDecodableEscape(s string) bool {
+// firstEscape returns the index of the first '%' followed by two hex digits, which
+// is what decodeLenient rewrites, or -1 when s holds none.
+func firstEscape(s string) int {
 	for i := range len(s) {
 		if isEscapeAt(s, i) {
-			return true
+			return i
 		}
 	}
-	return false
+	return -1
 }
 
 // isEscapeAt reports whether a well-formed percent-escape starts at s[i].
@@ -700,34 +803,54 @@ func unhexDigit(c byte) byte {
 // a truncated "[" where the host should be. The literal must parse as an IP, so a
 // bracket-prefixed username such as "[user:secret" still masks at its real colon.
 func userinfoColon(userinfo string) int {
-	from := 0
-	if strings.HasPrefix(userinfo, "[") {
-		if end := strings.IndexByte(userinfo, ']'); end > 0 {
-			literal := userinfo[1:end]
-			// A zone ID ("%25eth0" once percent-encoded) is not part of the address.
-			if pct := strings.IndexByte(literal, '%'); pct >= 0 {
-				literal = literal[:pct]
-			}
-			if net.ParseIP(literal) != nil {
-				from = end + 1
-			}
-		} else if net.ParseIP(userinfo[1:]) != nil {
-			// No closing ']': the delimiter the caller found sits inside the bracket
-			// because url.Parse rejected the authority (an invalid '%40' zone lands
-			// here, issue #62) and the ']' fell past it. Only when the ENTIRE span
-			// after '[' is a valid IP is it the host literal with no password to mask,
-			// so return -1. net.ParseIP rejects a zone or a ':' after the address, so a
-			// span like "[192.168.0.1%x:secret" is NOT taken as bare host: it falls
-			// through and its ':secret' is masked below. (Stripping at '%' first would
-			// misread that as a zoned address and leak the password.)
-			return -1
-		}
+	from, ok := userinfoSearchStart(userinfo)
+	if !ok {
+		return -1
 	}
 	colon := strings.IndexByte(userinfo[from:], ':')
 	if colon < 0 {
 		return -1
 	}
 	return from + colon
+}
+
+// userinfoSearchStart returns the offset in userinfo at which a username/password
+// separator may legitimately begin, skipping a leading bracketed IP literal whose
+// own colons belong to the address rather than to a credential. ok is false when
+// the whole span is such a literal, which carries no password span at all.
+//
+// It exists as a separate function because the encoded-separator search (issue #75)
+// has to cover EXACTLY the span this offset opens, no more and no less. Searching
+// the whole userinfo instead reports the address's own colons and over-masks every
+// bracketed host; searching past the raw colon instead reports a port or tail colon
+// and leaves the real credential standing in front of the mask.
+func userinfoSearchStart(userinfo string) (from int, ok bool) {
+	if !strings.HasPrefix(userinfo, "[") {
+		return 0, true
+	}
+	if end := strings.IndexByte(userinfo, ']'); end > 0 {
+		literal := userinfo[1:end]
+		// A zone ID ("%25eth0" once percent-encoded) is not part of the address.
+		if pct := strings.IndexByte(literal, '%'); pct >= 0 {
+			literal = literal[:pct]
+		}
+		if net.ParseIP(literal) != nil {
+			return end + 1, true
+		}
+		return 0, true
+	}
+	if net.ParseIP(userinfo[1:]) != nil {
+		// No closing ']': the delimiter the caller found sits inside the bracket
+		// because url.Parse rejected the authority (an invalid '%40' zone lands
+		// here, issue #62) and the ']' fell past it. Only when the ENTIRE span
+		// after '[' is a valid IP is it the host literal with no password to mask.
+		// net.ParseIP rejects a zone or a ':' after the address, so a span like
+		// "[192.168.0.1%x:secret" is NOT taken as bare host: it falls through and
+		// its ':secret' is masked. (Stripping at '%' first would misread that as a
+		// zoned address and leak the password.)
+		return 0, false
+	}
+	return 0, true
 }
 
 // lastAtDelimiter returns the index in s of the position that acts as the

--- a/config_test.go
+++ b/config_test.go
@@ -482,6 +482,34 @@ func TestSafeHost(t *testing.T) {
 		{"fails closed on an encoded userinfo colon with an encoded delimiter", "https://admin%3Asekret%40centreon.example.com", "https://xxxxx"},
 		{"fails closed on a lowercase encoded userinfo colon", "https://admin%3asekret@centreon.example.com", "https://xxxxx"},
 		{"fails closed on the scheme-less encoded-colon form", "admin%3Asekret@centreon.example.com", "xxxxx"},
+		// The same shapes behind an explicit port and behind a bracketed IPv6 literal.
+		// These are the mainstream deployment, not a corner case, and the first fix for
+		// #75 missed them: maskAmbiguousAuthority located the username boundary with
+		// userinfoColon over the WHOLE post-marker span, and on this path the userinfo
+		// carries no raw ':' by construction, so the first raw colon it found was the
+		// PORT colon. It masked the port and returned the credential verbatim. Every
+		// row above uses a portless host, which is exactly why the gap survived.
+		{"fails closed on an encoded userinfo colon behind a port", "https://admin%3Asekret@centreon.example.com:8443", "https://xxxxx"},
+		{"fails closed on an encoded userinfo colon behind a port with an encoded delimiter", "https://admin%3Asekret%40centreon.example.com:8443", "https://xxxxx"},
+		{"fails closed on the scheme-less encoded-colon form behind a port", "admin%3Asekret@centreon.example.com:8443", "xxxxx"},
+		{"fails closed on an encoded userinfo colon before a bracketed IPv6 host", "https://uzer%3Asekret@[::1]", "https://xxxxx"},
+		{"fails closed on an encoded userinfo colon before a bracketed IPv6 host with a port", "https://uzer%3Asekret@[2001:db8::1]:8443", "https://xxxxx"},
+		// A raw ':' inside a bracketed literal must not disarm the encoded-separator
+		// check. userinfoColon deliberately reports no separator for a bracketed
+		// reading, so gating that check on "the userinfo holds no raw ':'" exempted
+		// exactly the inputs whose colons belong to an address, and they leaked.
+		{"fails closed on an encoded colon after a bracketed literal", "https://[::1]%3Asekret@centreon.example.com", "https://xxxxx"},
+		{"fails closed on an encoded colon after a bracketed link-local literal", "https://[fe80::1]%3Asekret@centreon.example.com", "https://xxxxx"},
+		// The bracketed-authority carve-out reaches its verdict through
+		// tailCarriesPassword, which searched the tail for a RAW ':' and could not see
+		// a delimiter whose digits were encoded. Both spellings must defeat it.
+		{"masks an encoded colon in the tail of a bracketed authority", "https://[::1]/admin%3Asekret@centreon.example.com", "https://xxxxx"},
+		{"masks a digit-encoded delimiter in the tail of a bracketed authority", "https://[::1]/p:sekret%25%34%30centreon.example.com", "https://[::1]/p:xxxxx"},
+		// A delimiter without a separator is not a credential. These carry a '@' that
+		// only decoding reveals, or exhaust the decode bound outright, and hold no
+		// secret at all; masking them would drop a hostname to hide nothing.
+		{"leaves a digit-encoded @ with no separator unchanged", "https://example.com/path/%25%34%30", "https://example.com/path/%25%34%30"},
+		{"leaves a path nested past the decode bound unchanged", "https://centreon.example.com/100%25252525", "https://centreon.example.com/100%25252525"},
 		// Control isolating the cause to the colon: encoding a character in the
 		// USERNAME changes nothing, because the separator is still raw.
 		{"masks normally when only a username character is encoded", "https://ad%6Din:sekret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
@@ -559,23 +587,44 @@ func TestSafeHost(t *testing.T) {
 // not the reason.
 func TestSafeHostNeverLeaksPassword(t *testing.T) {
 	t.Parallel()
-	grid := credentialHostGrid()
-	// Without this the whole test passes vacuously if the builder ever returns
-	// nothing, which is the failure mode a pure absence assertion cannot see.
-	if len(grid) < 1000 {
-		t.Fatalf("credentialHostGrid() returned %d hosts, expected a full grid", len(grid))
+	// Each family is asserted to contribute rows BEFORE being swept. Checking only
+	// the first builder's length, as this test used to, left every later family free
+	// to contribute nothing while the absence assertion still reported success: a
+	// vacuous pass is exactly the failure mode a pure absence assertion cannot see,
+	// and appending to an already-large slice hides it.
+	families := []struct {
+		name string
+		rows []string
+	}{
+		// The raw '@' credential form, and the percent-encoded delimiter of issue #62
+		// once and twice encoded. The encoded ones carry no raw '@' at all, so before
+		// that fix safeHost either returned them unchanged or masked to a non-existent
+		// raw '@'. The display test deliberately does not get the encoded joins.
+		{"raw @ delimiter", credentialHostGrid()},
+		{"%40 delimiter", credentialHostGridJoined("%40")},
+		{"%2540 delimiter", credentialHostGridJoined("%2540")},
+		// Issue #68: the delimiter's hex digits themselves encoded, whole and partial.
+		// Neither matches the flat %(25)*40 shape, so the masker found no delimiter.
+		{"%25%34%30 delimiter", credentialHostGridJoined("%25%34%30")},
+		{"%254%30 delimiter", credentialHostGridJoined("%254%30")},
+		// Issue #75: the userinfo SEPARATOR encoded. Go splits userinfo on a raw ':'
+		// only, so these parse as a bare username with no password and url.Redacted
+		// masks nothing. Swept with both delimiter spellings and with the separator
+		// nested twice, because the guards for this family are spelled three different
+		// ways across maskAuthorityPassword, redactedCoversCredential and
+		// reparsedAuthority. credentialGridHosts supplies the ports and bracketed IPv6
+		// literals that the hand-written rows for this family originally all missed.
+		{"%3A separator", credentialHostGridSeparated("%3A", "@")},
+		{"%3A separator, %40 delimiter", credentialHostGridSeparated("%3A", "%40")},
+		{"%253A separator", credentialHostGridSeparated("%253A", "@")},
 	}
-	// Also sweep the percent-encoded delimiter (issue #62 family 2), once and twice
-	// encoded. These inputs carry no raw '@', so before the fix safeHost either
-	// returned them unchanged or masked to a non-existent raw '@'; the marker
-	// survived. The display test does not get these joins, see its note.
-	grid = append(grid, credentialHostGridJoined("%40")...)
-	grid = append(grid, credentialHostGridJoined("%2540")...)
-	// Issue #68: the delimiter's hex digits themselves percent-encoded, whole and
-	// partial. Neither carries a raw '@' nor matches the flat %(25)*40 shape, so
-	// before the fix the masker found no delimiter at all and returned the input.
-	grid = append(grid, credentialHostGridJoined("%25%34%30")...)
-	grid = append(grid, credentialHostGridJoined("%254%30")...)
+	var grid []string
+	for _, f := range families {
+		if len(f.rows) < 1000 {
+			t.Fatalf("family %q contributed %d hosts, expected a full grid", f.name, len(f.rows))
+		}
+		grid = append(grid, f.rows...)
+	}
 
 	fragmentRows := 0
 	failures := 0
@@ -729,8 +778,13 @@ func TestRedactedHostPlaceholderLiteral(t *testing.T) {
 // flake it. Replacing maxDecodeRounds in decodesToContain with an unbounded loop is
 // the change this is meant to catch, and doing so measures 17632x (1.156GB on a
 // 64KB input), reproducing the issue #62 figure almost exactly.
+// Deliberately NOT t.Parallel: testing.Benchmark derives AllocedBytesPerOp from
+// process-wide runtime.MemStats deltas, so every allocation a concurrently running
+// parallel test makes inside the benchmark window is charged to this one. Measured
+// under the CI command (go test -race ./...) with t.Parallel on, the ratio rose
+// from 7.9x to 15.5x against the 20x bound, which a slower runner would push over.
+// Serial, it measures 7.88x with no run-to-run spread.
 func TestSafeHostBoundsAllocationOnNestedEscapes(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		name string
 		host string
@@ -746,7 +800,6 @@ func TestSafeHostBoundsAllocationOnNestedEscapes(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			var got string
 			//nolint:thelper // this is the benchmark body itself, not a helper.
 			res := testing.Benchmark(func(b *testing.B) {
@@ -769,6 +822,47 @@ func TestSafeHostBoundsAllocationOnNestedEscapes(t *testing.T) {
 					float64(res.AllocedBytesPerOp())/float64(len(tt.host)), limit)
 			}
 		})
+	}
+}
+
+// TestValidateHostSchemeErrorsNeverEchoACredential pins that a REJECTION message
+// cannot reprint the credential it is rejecting. Every message already quotes
+// safeHost's masked form, but Go's own parse reason quotes the offending span too
+// ("invalid port \":<password>\" after host"), so unwrapping one layer and
+// formatting it put the password back into the very sentence that had just masked
+// it (CWE-532). The messages reach a log at main.go for CENTREON_HOST and at the
+// gateway host-rejected line for a caller-supplied X-Centreon-Host header.
+func TestValidateHostSchemeErrorsNeverEchoACredential(t *testing.T) {
+	t.Parallel()
+	grid := credentialHostGrid()
+	grid = append(grid, credentialHostGridJoined("%40")...)
+	grid = append(grid, credentialHostGridJoined("%25%34%30")...)
+	grid = append(grid, credentialHostGridSeparated("%3A", "@")...)
+	if len(grid) < 1000 {
+		t.Fatalf("grid returned %d hosts, expected a full grid", len(grid))
+	}
+
+	rejected, failures := 0, 0
+	for _, host := range grid {
+		err := validateHostScheme(host, true)
+		if err == nil {
+			continue
+		}
+		rejected++
+		if msg := err.Error(); strings.Contains(msg, passwordMarker) || strings.Contains(msg, passwordFragment) {
+			failures++
+			if failures <= 10 {
+				t.Errorf("validateHostScheme(%q) error leaks the password:\n  %s", host, msg)
+			}
+		}
+	}
+	if failures > 10 {
+		t.Errorf("validateHostScheme leaked the password in %d of %d rejection messages", failures, rejected)
+	}
+	// Positive control: an assertion over rejection messages proves nothing if
+	// nothing in the grid is actually rejected.
+	if rejected < 1000 {
+		t.Fatalf("only %d grid hosts were rejected, too few to prove anything", rejected)
 	}
 }
 
@@ -812,6 +906,19 @@ func credentialHostGrid() []string { return credentialHostGridJoined("@") }
 // password span. Only the safeHost sweep feeds the encoded joins; the display
 // test deliberately does not (see the note there).
 func credentialHostGridJoined(join string) []string {
+	return credentialHostGridSeparated(":", join)
+}
+
+// credentialHostGridSeparated is credentialHostGridJoined with the userinfo
+// SEPARATOR parameterised as well as the delimiter. Until issue #75 the grid built
+// every userinfo as username+":"+password, so the separator was the one axis it
+// held constant, and the whole encoded-separator family ("%3A") was reachable only
+// through hand-written table rows. That gap hid a Critical leak: the first #75 fix
+// masked correctly for a portless host and echoed the entire credential whenever
+// the host carried a port, because every hand-written row happened to be portless.
+// The lesson is issue #65 item 8 at a different axis: ask which dimension the grid
+// holds constant and whether the root cause can vary it.
+func credentialHostGridSeparated(sep, join string) []string {
 	schemes := []string{"https://", "http://", "//", "://", "", "https:"}
 	usernames := []string{
 		"admin", "us/er", "us?er", "us#er", "us.er", "[user", "us[er",
@@ -848,7 +955,7 @@ func credentialHostGridJoined(join string) []string {
 	userinfos := make([]string, 0, len(usernames)*len(passwords))
 	for _, username := range usernames {
 		for _, password := range passwords {
-			userinfos = append(userinfos, username+":"+password)
+			userinfos = append(userinfos, username+sep+password)
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -520,11 +520,16 @@ func TestSafeHost(t *testing.T) {
 		{"fails closed on an encoded separator ahead of a raw one behind a port", "https://admin%3Asekret:x@centreon.example.com:8443", "https://xxxxx"},
 		// Pins the region the encoded-separator search covers. Widening it to the whole
 		// userinfo makes a bracketed literal's own colons read as a separator and masks
-		// this to "https://xxxxx", which is why the search starts past the bracket.
-		// Without this row that narrowing is unpinned and the whole suite stays green
-		// when it is reverted.
+		// these to "https://xxxxx", which is why the search starts past the bracket.
+		// Four pre-existing bracketed rows also fail under that widening, so these are
+		// the direct statement of the invariant rather than its only guard.
 		{"leaves a bracketed IPv6 userinfo with no separator unchanged", "https://[::1]@centreon.example.com", "https://[::1]@centreon.example.com"},
-		{"leaves a bracketed IPv6 userinfo with a port and no separator unchanged", "https://[2001:db8::1]@centreon.example.com", "https://[2001:db8::1]@centreon.example.com"},
+		{"leaves a longer bracketed IPv6 userinfo with no separator unchanged", "https://[2001:db8::1]@centreon.example.com", "https://[2001:db8::1]@centreon.example.com"},
+		// Pins the delimiter half of maskAmbiguousAuthority's guard, which the rest of
+		// the suite leaves deletable: dropping it keeps the username span whenever a
+		// credential delimiter precedes the colon, which is where the port colon and
+		// the real credential both live.
+		{"fails closed on an encoded separator inside a bracketed span before a port", "https://[::1%3Asekret]@centreon.example.com:8443/x%25%34%30", "https://xxxxx"},
 		// Control isolating the cause to the colon: encoding a character in the
 		// USERNAME changes nothing, because the separator is still raw.
 		{"masks normally when only a username character is encoded", "https://ad%6Din:sekret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},

--- a/config_test.go
+++ b/config_test.go
@@ -510,6 +510,21 @@ func TestSafeHost(t *testing.T) {
 		// secret at all; masking them would drop a hostname to hide nothing.
 		{"leaves a digit-encoded @ with no separator unchanged", "https://example.com/path/%25%34%30", "https://example.com/path/%25%34%30"},
 		{"leaves a path nested past the decode bound unchanged", "https://centreon.example.com/100%25252525", "https://centreon.example.com/100%25252525"},
+		// An encoded separator in the USERNAME moves the real boundary earlier than the
+		// raw one Go split on, so url.Redacted masks only the fragment after the raw
+		// ':' and echoes everything before it. redactedCoversCredential returned true
+		// on hasPassword before consulting the encoded-separator guard at all, which
+		// made this the last reachable shape of the family: validateHostScheme accepts
+		// it, so it runs normally and reaches a log on every line.
+		{"fails closed on an encoded separator ahead of a raw one", "https://admin%3Asekret:x@centreon.example.com", "https://xxxxx"},
+		{"fails closed on an encoded separator ahead of a raw one behind a port", "https://admin%3Asekret:x@centreon.example.com:8443", "https://xxxxx"},
+		// Pins the region the encoded-separator search covers. Widening it to the whole
+		// userinfo makes a bracketed literal's own colons read as a separator and masks
+		// this to "https://xxxxx", which is why the search starts past the bracket.
+		// Without this row that narrowing is unpinned and the whole suite stays green
+		// when it is reverted.
+		{"leaves a bracketed IPv6 userinfo with no separator unchanged", "https://[::1]@centreon.example.com", "https://[::1]@centreon.example.com"},
+		{"leaves a bracketed IPv6 userinfo with a port and no separator unchanged", "https://[2001:db8::1]@centreon.example.com", "https://[2001:db8::1]@centreon.example.com"},
 		// Control isolating the cause to the colon: encoding a character in the
 		// USERNAME changes nothing, because the separator is still raw.
 		{"masks normally when only a username character is encoded", "https://ad%6Din:sekret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
@@ -948,6 +963,12 @@ func credentialHostGridSeparated(sep, join string) []string {
 		passwordFragment + "/" + passwordMarker, passwordFragment + "?" + passwordMarker,
 		passwordFragment + "#" + passwordMarker, passwordMarker + "/" + passwordFragment,
 		"p@" + passwordFragment + passwordMarker,
+		// Fragment before a RAW ':', marker after it. Combined with an encoded
+		// separator this is the only shape that exposes the last #75 family: Go splits
+		// on the raw colon, so url.Redacted masks the marker and echoes everything in
+		// front of it, and a marker-only assertion sees a correctly redacted string.
+		// Without this row the 238464-row sweep passes while the password leaks.
+		passwordFragment + ":" + passwordMarker,
 	}
 	hosts := credentialGridHosts
 	tails := []string{"", "/mon", "?q=1", "#f", "/a@b", "/d:" + passwordMarker + "@f"}

--- a/config_test.go
+++ b/config_test.go
@@ -510,6 +510,19 @@ func TestSafeHost(t *testing.T) {
 		// secret at all; masking them would drop a hostname to hide nothing.
 		{"leaves a digit-encoded @ with no separator unchanged", "https://example.com/path/%25%34%30", "https://example.com/path/%25%34%30"},
 		{"leaves a path nested past the decode bound unchanged", "https://centreon.example.com/100%25252525", "https://centreon.example.com/100%25252525"},
+		// The accepted cost of that bound. Nesting past maxDecodeRounds is reported as
+		// uncertainty, and combined with a ':' anywhere ahead of it the input is
+		// indistinguishable from a credential whose delimiter is hiding deeper, so it
+		// is masked. No secret is exposed; the operator loses the tail. This row exists
+		// to make the trade deliberate rather than incidental.
+		{"masks a credential-free URL whose only colon precedes an over-nested escape", "https://example.com/p:%25252525", "https://example.com/p:xxxxx"},
+		// And the reason the separator search cannot simply be narrowed to the
+		// authority to avoid that cost. Here the ':' is ALSO only in the path, the
+		// delimiter is again reachable only by decoding past the bound, and the input
+		// IS a credential: url.Parse mis-reads "user:pass" spanning a '/' (issue #55),
+		// which is why the search spans the whole post-marker string. Restricting it to
+		// the authority would return this verbatim and leak the password.
+		{"masks a mis-parsed credential whose colon is only in the path", "https://x/admin:pw%25252525%25252534%25252530host", "https://x/admin:xxxxx"},
 		// An encoded separator in the USERNAME moves the real boundary earlier than the
 		// raw one Go split on, so url.Redacted masks only the fragment after the raw
 		// ':' and echoes everything before it. redactedCoversCredential returned true

--- a/config_test.go
+++ b/config_test.go
@@ -244,6 +244,7 @@ func TestLoadConfig_HTTPPort(t *testing.T) {
 // opt-in, and a missing or unsupported scheme, an unparseable URL, or a URL naming
 // no hostname is rejected outright.
 func TestValidateHostScheme(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		host      string
@@ -301,6 +302,7 @@ func TestValidateHostScheme(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := validateHostScheme(tt.host, tt.allowHTTP)
 			switch {
 			case tt.wantErr == "" && err != nil:
@@ -323,6 +325,7 @@ func TestValidateHostScheme(t *testing.T) {
 // its tail, are still returned byte for byte unchanged. These rows are examples;
 // TestSafeHostNeverLeaksPassword sweeps the class.
 func TestSafeHost(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		host string
@@ -447,6 +450,58 @@ func TestSafeHost(t *testing.T) {
 		// so a bound cannot be outrun to leave the password verbatim (5 layers here).
 		{"masks a five-layer encoded delimiter", "https://admin:secret%2525252540centreon.example.com", "https://admin:xxxxx%2525252540centreon.example.com"},
 		{"masks a raw @ password ahead of a five-layer encoded delimiter", "https://admin:p@ssword%2525252540centreon.example.com", "https://admin:xxxxx%2525252540centreon.example.com"},
+		// Issue #68: the delimiter's own hex digits can be encoded, so "@" can be
+		// written "%25%34%30" ("%25"->'%', "%34"->'4', "%30"->'0'). lastAtDelimiter's
+		// flat %(25)*40 scan cannot see that shape. Locating it exactly would mean
+		// mapping an offset back through every decode round, so safeHost fails closed
+		// and masks from the first userinfo colon instead, losing the host. That is the
+		// issue #61 trade already made by the "behind a port" row above, and no
+		// operator writes this form: validateHostScheme rejects it outright, so it is
+		// only reachable through the caller-supplied X-Centreon-Host header.
+		{"fails closed on a delimiter whose hex digits are encoded", "https://admin:secret%25%34%30centreon.example.com", "https://admin:xxxxx"},
+		{"fails closed on a raw @ password ahead of a digit-encoded delimiter", "https://admin:p@ssword%25%34%30centreon.example.com", "https://admin:xxxxx"},
+		{"fails closed on a partially digit-encoded delimiter", "https://admin:secret%254%30centreon.example.com", "https://admin:xxxxx"},
+		// The decode is lenient: an unrelated malformed escape later in the string must
+		// not stop the delimiter being found. url.PathUnescape cannot be used here
+		// because it rejects the whole string on the first bad escape.
+		{"fails closed on a digit-encoded delimiter beside a malformed escape", "https://admin:secret%25%34%30centreon.example.com/%zz", "https://admin:xxxxx"},
+		// Nested past the decode bound: decoding is still making progress when the
+		// rounds run out, so a delimiter could be hiding deeper and safeHost fails
+		// closed rather than guess.
+		{"fails closed on a delimiter nested past the decode bound", "https://admin:secret%25252525%25252534%25252530centreon.example.com", "https://admin:xxxxx"},
+		// The mirror image: an escape run that decodes to "40" and never to '@' is not
+		// a delimiter, so the input is left alone. Without this the decoder could be
+		// made to treat any digit-bearing escape run as a credential delimiter.
+		{"leaves a lookalike encoded run that decodes to 40 unchanged", "https://host/%zz/pw%2534%30q", "https://host/%zz/pw%2534%30q"},
+		// Issue #75: the userinfo COLON can be percent-encoded too. Go splits userinfo
+		// on a RAW ':' only, so "admin%3ASEKRIT@host" parses as a bare username with no
+		// password and url.Redacted masks nothing. The username is dropped along with
+		// the host here because the colon's position is only known after decoding, and
+		// safeHost masks rather than maps the offset back.
+		{"fails closed on an encoded userinfo colon with a raw delimiter", "https://admin%3Asekret@centreon.example.com", "https://xxxxx"},
+		{"fails closed on an encoded userinfo colon with an encoded delimiter", "https://admin%3Asekret%40centreon.example.com", "https://xxxxx"},
+		{"fails closed on a lowercase encoded userinfo colon", "https://admin%3asekret@centreon.example.com", "https://xxxxx"},
+		{"fails closed on the scheme-less encoded-colon form", "admin%3Asekret@centreon.example.com", "xxxxx"},
+		// Control isolating the cause to the colon: encoding a character in the
+		// USERNAME changes nothing, because the separator is still raw.
+		{"masks normally when only a username character is encoded", "https://ad%6Din:sekret@centreon.example.com", "https://admin:xxxxx@centreon.example.com"},
+		// A userinfo with no colon in any encoding has no password span, so it is left
+		// alone. This is the row that stops the encoded-colon guard from turning every
+		// bare username into a fail-closed mask.
+		{"leaves a username-only userinfo unchanged", "https://user@centreon.example.com", "https://user@centreon.example.com"},
+		// url.Redacted canonicalises the userinfo, so the escape is decoded here. That
+		// is normalisation of a username, not a leak: no colon means no password span.
+		{"leaves a username-only userinfo with an encoded character intact", "https://us%65r@centreon.example.com", "https://user@centreon.example.com"},
+		// Issue #59 item 5: pins lastAtDelimiter's last-'@'-wins rule through the one
+		// path that can never migrate to url.Redacted or the reparse. The "%zz" forces
+		// url.Parse to fail and the second '@' makes safeHost skip the reparse, so only
+		// the textual masker can produce this output. Swapping LastIndexByte for
+		// IndexByte in lastAtDelimiter yields ".../a:xxxxx@c@d" instead.
+		{"masks to the last raw @ in an unparseable URL", "https://host/%zz/a:b@c@d", "https://host/%zz/a:xxxxx@d"},
+		// Issue #59 item 6: pins the scheme-less reparse block. Deleting it drops
+		// safeHost to the textual masker, which cannot canonicalise the host, so the
+		// output keeps the raw "é" instead of percent-encoding it.
+		{"masks scheme-less userinfo with a non-ASCII host via the reparse", "admin:pw@centréon.example.com", "admin:xxxxx@centr%C3%A9on.example.com"},
 		// The issue #61 log-integrity trade extended to an encoded delimiter: once a
 		// real userinfo is decoded but a %40 survives in the tail, the input is the
 		// same ambiguous shape as a password whose own delimiter is encoded (compare
@@ -485,6 +540,7 @@ func TestSafeHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := safeHost(tt.host); got != tt.want {
 				t.Errorf("safeHost(%q) = %q, want %q", tt.host, got, tt.want)
 			}
@@ -502,6 +558,7 @@ func TestSafeHost(t *testing.T) {
 // the same oracle from separate username and password arguments, so the oracle is
 // not the reason.
 func TestSafeHostNeverLeaksPassword(t *testing.T) {
+	t.Parallel()
 	grid := credentialHostGrid()
 	// Without this the whole test passes vacuously if the builder ever returns
 	// nothing, which is the failure mode a pure absence assertion cannot see.
@@ -514,7 +571,13 @@ func TestSafeHostNeverLeaksPassword(t *testing.T) {
 	// survived. The display test does not get these joins, see its note.
 	grid = append(grid, credentialHostGridJoined("%40")...)
 	grid = append(grid, credentialHostGridJoined("%2540")...)
+	// Issue #68: the delimiter's hex digits themselves percent-encoded, whole and
+	// partial. Neither carries a raw '@' nor matches the flat %(25)*40 shape, so
+	// before the fix the masker found no delimiter at all and returned the input.
+	grid = append(grid, credentialHostGridJoined("%25%34%30")...)
+	grid = append(grid, credentialHostGridJoined("%254%30")...)
 
+	fragmentRows := 0
 	failures := 0
 	for _, host := range grid {
 		// Positive control: the input must actually carry the marker, otherwise
@@ -522,7 +585,10 @@ func TestSafeHostNeverLeaksPassword(t *testing.T) {
 		if !strings.Contains(host, passwordMarker) {
 			t.Fatalf("grid host %q does not contain the marker, the builder is wrong", host)
 		}
-		if got := safeHost(host); strings.Contains(got, passwordMarker) {
+		if strings.Contains(host, passwordFragment) {
+			fragmentRows++
+		}
+		if got := safeHost(host); strings.Contains(got, passwordMarker) || strings.Contains(got, passwordFragment) {
 			failures++
 			// Cap the output: a regression here leaks thousands of rows at once.
 			if failures <= 20 {
@@ -532,6 +598,14 @@ func TestSafeHostNeverLeaksPassword(t *testing.T) {
 	}
 	if failures > 20 {
 		t.Errorf("safeHost leaked the password in %d of %d grid hosts", failures, len(grid))
+	}
+	// Positive control for the fragment half of the assertion above. Without it the
+	// fragment check passes vacuously if the marker-before-delimiter passwords are
+	// ever dropped from the builder, which is exactly the blindspot issue #65 item 8
+	// records: every original grid password put the marker last, so an output that
+	// echoed the span BEFORE the marker satisfied a marker-only assertion.
+	if fragmentRows < 1000 {
+		t.Fatalf("only %d grid hosts carry the fragment, the builder lost its marker-before-delimiter passwords", fragmentRows)
 	}
 }
 
@@ -564,6 +638,7 @@ func namesAnIntendedHost(out string) bool {
 // hand-written TestDisplayHost rows were written from; those rows are the
 // reproduction, and this is the guard against the next shape.
 func TestDisplayHostNamesOnlyARealHost(t *testing.T) {
+	t.Parallel()
 	// Only the raw-'@' grid. The "%40"/"%2540" joins the safeHost sweep adds are
 	// covered by TestDisplayHostEncodedJoinsNeverEchoACredential: since the issue #70
 	// fix they fail closed on every row, so they cannot contribute to the echoed>0
@@ -608,6 +683,7 @@ func TestDisplayHostNamesOnlyARealHost(t *testing.T) {
 // every row, and the raw-'@' grid in TestDisplayHostNamesOnlyARealHost keeps the
 // availability control.
 func TestDisplayHostEncodedJoinsNeverEchoACredential(t *testing.T) {
+	t.Parallel()
 	for _, join := range []string{"%40", "%2540"} {
 		grid := credentialHostGridJoined(join)
 		if len(grid) < 1000 {
@@ -637,14 +713,78 @@ func TestDisplayHostEncodedJoinsNeverEchoACredential(t *testing.T) {
 // changed to anything, including something that reads as a host or a credential, with
 // the whole suite still green.
 func TestRedactedHostPlaceholderLiteral(t *testing.T) {
+	t.Parallel()
 	if redactedHostPlaceholder != "(redacted host)" {
 		t.Errorf("redactedHostPlaceholder = %q, want %q", redactedHostPlaceholder, "(redacted host)")
+	}
+}
+
+// TestSafeHostBoundsAllocationOnNestedEscapes pins the DoS property, not the
+// redaction. An earlier design peeled one percent-encoding layer per candidate
+// position, rebuilding the string each time; that was measured at 1.15GB allocated
+// per call on a 64KB nested input, roughly 17500x the input (issue #62). safeHost
+// now decodes the whole span a fixed number of times instead, so allocation is a
+// small multiple of the input at ANY nesting depth. Both cases below measure 7.9x;
+// the 20x bound is deliberately loose so machine and Go-version differences cannot
+// flake it. Replacing maxDecodeRounds in decodesToContain with an unbounded loop is
+// the change this is meant to catch, and doing so measures 17632x (1.156GB on a
+// 64KB input), reproducing the issue #62 figure almost exactly.
+func TestSafeHostBoundsAllocationOnNestedEscapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		host string
+	}{
+		// Re-encoding '%' appends two bytes per layer ("%25" -> "%2525" -> "%252525"),
+		// so a 64KB input nests about 32000 layers deep and every round of decoding
+		// makes progress. This is the shape that must NOT be decoded to exhaustion.
+		// It deliberately does not end in "40": a flat %(25)*40 delimiter is found by
+		// escapeEncodesAt without decoding at all, which would short-circuit the very
+		// path this test exists to bound.
+		{"deeply nested %25 layers", "https://admin:secret%" + strings.Repeat("25", 32*1024) + "x"},
+		{"deeply nested layers with a real delimiter", "https://admin:secret%" + strings.Repeat("25", 32*1024) + "%34%30host"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var got string
+			//nolint:thelper // this is the benchmark body itself, not a helper.
+			res := testing.Benchmark(func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					got = safeHost(tt.host)
+				}
+			})
+			// Positive control: a benchmark that never ran would report 0 B/op and pass
+			// the bound vacuously.
+			if res.N == 0 || got == "" {
+				t.Fatalf("benchmark did not run (N=%d, output %q)", res.N, got)
+			}
+			if strings.Contains(got, "secret") {
+				t.Errorf("safeHost leaked the password on %s: %.80q", tt.name, got)
+			}
+			if limit := int64(len(tt.host)) * 20; res.AllocedBytesPerOp() > limit {
+				t.Errorf("safeHost allocated %d B/op on a %d byte input (%.1fx), want at most %d B/op",
+					res.AllocedBytesPerOp(), len(tt.host),
+					float64(res.AllocedBytesPerOp())/float64(len(tt.host)), limit)
+			}
+		})
 	}
 }
 
 // passwordMarker appears only in password position in the credentialHostGrid
 // inputs, so finding it in safeHost output is unambiguously a leak.
 const passwordMarker = "SEKRIT"
+
+// passwordFragment is a second sentinel placed BEFORE passwordMarker in some grid
+// passwords, so the sweep can see a partial leak. Issue #65 item 8: every original
+// grid password carried the marker at or near its end, so an output that echoed the
+// password span preceding the marker satisfied a marker-only absence assertion. The
+// two safeHost families closed in issue #62 both leaked that way and kept the grid
+// green. Digit-only on purpose: it keeps the all-numeric prefix shape that makes
+// url.Parse read a password as a port (issue #55), and it collides with nothing in
+// credentialGridHosts, whose only digits are the 8443 port and the IPv6 literals.
+const passwordFragment = "31337"
 
 // credentialGridHosts are the authorities credentialHostGrid builds every input
 // around. namesAnIntendedHost reads this same list, so the grid and the assertion
@@ -693,6 +833,14 @@ func credentialHostGridJoined(join string) []string {
 		// url.Redacted masks only the fragment and the marker leaks; the marker-only
 		// assertion can finally see the family-1 class (issue #62).
 		"x@" + passwordMarker + "/p", "x@" + passwordMarker + "?q", "x@" + passwordMarker + "#f",
+		// Marker-before-delimiter passwords (issue #65 item 8). The fragment leads, so
+		// an output that echoes only the span ahead of the marker still trips the
+		// sweep. The last two put the fragment after the marker and after an internal
+		// raw '@', the geometry where the masker picks the earlier delimiter and leaves
+		// the rest of the password standing.
+		passwordFragment + "/" + passwordMarker, passwordFragment + "?" + passwordMarker,
+		passwordFragment + "#" + passwordMarker, passwordMarker + "/" + passwordFragment,
+		"p@" + passwordFragment + passwordMarker,
 	}
 	hosts := credentialGridHosts
 	tails := []string{"", "/mon", "?q=1", "#f", "/a@b", "/d:" + passwordMarker + "@f"}
@@ -729,6 +877,7 @@ func credentialHostGridJoined(join string) []string {
 // '@' survives after the authority, because url.Parse may then have read part of a
 // credential as the host (issue #57).
 func TestDisplayHost(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		host string
@@ -834,6 +983,7 @@ func TestDisplayHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := displayHost(tt.host); got != tt.want {
 				t.Errorf("displayHost(%q) = %q, want %q", tt.host, got, tt.want)
 			}


### PR DESCRIPTION
Closes #68. Closes #75.

`safeHost` redacts a Centreon base URL before it reaches a server log field (CWE-532). It located the userinfo boundary with raw byte searches over a string that is percent-encoded, so a boundary written in any encoding other than the literal one slipped past it and the password was echoed.

## The two shapes

**#68, the `@` delimiter.** `escapeEncodesAt` recognised only `%(25)*40`: a `@` whose leading `%` is re-encoded to any depth while the hex digits `4` and `0` stay literal. The digits can be encoded too, so `@` can be written `%25%34%30`, which decodes to `%40` and then to `@`.

**#75, the `:` separator.** Found while implementing #68 and filed separately. Go's `parseAuthority` splits userinfo on a RAW `:` only, so `https://admin%3Asecret@host` parses as a bare username `admin:secret` with no password at all, and `url.Redacted` masks nothing because as far as Go is concerned there is nothing to mask.

#75 is the more reachable of the two, which inverts the priority the original issue assumed:

```
validateHostScheme("https://admin:secret%25%34%30centreon.example.com") -> rejected (invalid port)
validateHostScheme("https://admin%3Asecret@centreon.example.com")       -> nil (ACCEPTED)
```

So #68's own shapes cannot occur in env mode at all, and are reachable only through the caller-supplied `X-Centreon-Host` header in gateway mode. The #75 shape is a fully valid `CENTREON_HOST` that starts normally and then prints the password on every log line.

## The fix

`decodesToTarget(s, target)` decodes leniently up to `maxDecodeRounds` and reports *found* and *uncertain* separately. Leniency is load-bearing: `url.PathUnescape` rejects a whole string on its first bad escape, so a `%zz` typo in a path would otherwise hide a delimiter elsewhere in the URL. The found/uncertain split is load-bearing too, because a credential needs BOTH a delimiter and a separator, and a deeply nested ordinary path exhausts the bound on both searches at once; treating that exhaustion as evidence for each in turn destroyed the hostname to hide nothing.

Where a credential is present but its boundary is only locatable after decoding, `safeHost` masks from the userinfo separator and drops the host rather than map an offset back through every decode round. The username survives when a raw colon marks where the password starts.

`userinfoSearchStart` returns exactly the region a separator may occupy, past a leading bracketed IP literal whose own colons belong to the address. All four sites that ask "where does the credential start" now ask it of that same region.

The bound is on decode ROUNDS rather than on layers because the discarded per-layer peel allocated 1.15GB per call on a 64KB nested input (#62). `TestSafeHostBoundsAllocationOnNestedEscapes` pins it at 7.9x the input, and 17632x if the bound is removed.

## Also fixed, pre-existing and in the same hazard class

`validateHostScheme` unwrapped one layer of `url.Error` specifically to avoid reprinting the credential, but Go's own reason for a mis-parsed authority is `invalid port ":<password>" after host`, which quotes it too. The masked host and the password shipped in the same sentence:

```
invalid host url "https://admin:xxxxx": invalid port ":p4ssw0rd%25%34%30centreon.example.com" after host
```

`urlParseReason` now maps the failure to one of four constants and never copies a string out of the error, the same fail-closed approach `internal/redact.Reason` takes for client-call errors. Those messages reach a log for `CENTREON_HOST` at startup and for a caller-supplied header in gateway mode.

## Folded-in batch items

#59 item 4 (`t.Parallel` in the pure config tests), item 5 (a named row for the last-`@` rule) and item 6 (a row pinning the scheme-less reparse), plus #65 item 8 (`passwordFragment`, a second sentinel placed BEFORE `passwordMarker` so the sweep can see a partial leak).

#59 item 1 needed no change; the godoc placement it describes is already correct on `main`. #59 item 5's stated premise is stale, and the measurement is [in a comment on that issue](https://github.com/tphakala/centreon-mcp-go/issues/59).

## What the review changed

The first commit here was correct only for the shapes its own tests used. Three gate rounds and a Gemini cross-check found, in order:

1. A **Critical** defect in the first fix: `maskAmbiguousAuthority` searched the whole authority for the username boundary, but on the #75 path the userinfo provably holds no raw colon, so the first one it found was always the PORT colon. It masked the port and returned the credential verbatim for every host written with one. Every hand-written #75 row happened to be portless, which is why it survived.
2. Three more paths with the same root cause, including a bracketed-IPv6 carve-out and a tail search that both looked for a raw `:` only.
3. A regression the first fix introduced in the other direction: credential-free URLs such as `https://example.com/path/%25%34%30` lost their hostname.
4. A **High** residual: `redactedCoversCredential` returned true the moment Go reported a password, so the encoded-separator guard below it never ran, and an encoded separator EARLIER than the raw one meant `url.Redacted` masked only the fragment after the raw colon.

The sweep could not see any of them, for the same structural reason each time: the grid parameterised the delimiter and held the SEPARATOR constant, and every generated password put the marker last, so a partial leak reads as a correct redaction. That is #65 item 8 recurring on two further axes. `credentialHostGridSeparated` now parameterises the separator, and one password puts the fragment before a raw colon. Either fix, reverted, now fails the sweep on its own.

## Verification

- No existing test expectation changed. Every input masked correctly before is masked identically now; only previously-leaking inputs moved.
- Differential harness over **1,402,885** generated inputs across `main`, and both fix waves: **0 new leaks, 0 new regressions**. Total leaks 1,206,600 on `main` to 33,570 in the structured corpus, with the residue being shapes `url.Parse` rejects outright.
- 20 sabotages, each build-checked BEFORE its verdict was read, because a mutant that fails to compile reports zero failures and reads exactly like a passing test.
- `go test -race ./...`, `go vet`, `golangci-lint` and `gofmt` clean.

## Not fixed here

#76 (unbounded `X-Centreon-Host` makes an unauthenticated request cost about 21ms and 10MB) is pre-existing and needs a length cap, which is a compatibility decision rather than a mechanical edit. This branch narrows the amplification: `decodeLenient` now copies literal runs instead of one byte at a time, verified identical over 1,000,000 generated inputs.

#77 batches 16 low-severity findings from the three rounds.
