### PR TITLE
feat: file-based secrets and token-mode startup validation (#82, #84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `CENTREON_PASSWORD_FILE` and `CENTREON_TOKEN_FILE` environment variables.
+  Secret credentials can now be read from mounted files (Docker and Kubernetes
+  secrets convention). A `_FILE` variable takes precedence over its inline
+  counterpart, and exactly one trailing newline (`\n` or `\r\n`) is trimmed.
+  A set but missing, unreadable, or empty file produces a configuration error. (#84)
+- `doctor` subcommand (`centreon-mcp-go doctor`) to verify configuration, check
+  network connectivity and API credentials, and report the Centreon Web version
+  with exit codes 0 (healthy), 1 (config error), 2 (unreachable), and 3 (bad
+  credentials). (#82)
 - `MCP_READ_ONLY` environment variable. When set to `true`, every tool that writes
   to Centreon is still listed but refuses with a tool-level error and performs no
   action, while the read tools work normally. Read-only is the safe default to
@@ -49,6 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Token-based authentication now performs a startup validation check (GET
+  `/monitoring/hosts/status`) during server boot in stdio and HTTP env-auth
+  modes, failing fast on a bad or expired token. Like password-mode's existing
+  login-at-boot, this means an unreachable platform now blocks startup instead
+  of the server starting and failing on the first tool call. (#82)
 - The `github.com/tphakala/centreon-go-client` dependency is updated to v2.1.0.
   v2.0.0 adopted upstream fixes for tools this server already ships: downtime and
   token timestamps are truncated to whole seconds (Centreon 25.10 rejects

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ All configuration is via environment variables.
 | `CENTREON_HOST`             | Yes      | (none)      | Centreon server base URL (e.g. `https://centreon.example.com`) |
 | `CENTREON_USERNAME`         | *        | (none)      | Username for session-based authentication                    |
 | `CENTREON_PASSWORD`         | *        | (none)      | Password for session-based authentication                    |
+| `CENTREON_PASSWORD_FILE`    | No       | (none)      | Read the password from this file; takes precedence over CENTREON_PASSWORD; one trailing newline is trimmed |
 | `CENTREON_TOKEN`            | *        | (none)      | API token (alternative to username + password)               |
+| `CENTREON_TOKEN_FILE`       | No       | (none)      | Read the API token from this file; takes precedence over CENTREON_TOKEN; one trailing newline is trimmed |
 | `CENTREON_ALLOW_SELF_SIGNED`| No       | `false`     | Accept self-signed TLS certificates                          |
 | `CENTREON_ALLOW_HTTP`       | No       | `false`     | Permit cleartext `http://` Centreon URLs. Off by default; `http` sends credentials unencrypted (CWE-319). |
 | `MCP_TRANSPORT`             | No       | `stdio`     | Transport mode: `stdio` or `http`                            |
@@ -71,7 +73,7 @@ All configuration is via environment variables.
 | `CENTREON_ALLOWED_HOSTS`    | No       | (none)      | Gateway mode only: comma-separated allowlist of accepted `X-Centreon-Host` values. Unset or empty means any host is accepted. |
 | `LOG_LEVEL`                 | No       | `info`      | Log level: `debug`, `info`, `warn`, or `error`               |
 
-\* Either `CENTREON_TOKEN` or both `CENTREON_USERNAME` and `CENTREON_PASSWORD` must be set. In `gateway` auth mode, credentials are supplied per-request via headers instead.
+\* Either `CENTREON_TOKEN` (or `CENTREON_TOKEN_FILE`) or both `CENTREON_USERNAME` and `CENTREON_PASSWORD` (or `CENTREON_PASSWORD_FILE`) must be set. In `gateway` auth mode, credentials are supplied per-request via headers instead.
 
 > **Note on redirects:** to protect the session token, the server never follows an HTTP redirect to a different host. Point `CENTREON_HOST` (and, in gateway mode, `X-Centreon-Host`) at the URL that serves the Centreon API directly. A host that redirects to a different hostname (for example an apex-to-`www` or a vanity-to-backend redirect) makes requests fail with `refusing cross-host redirect`; use the final resolved URL instead. Same-host redirects, including an `http` to `https` upgrade, are still followed.
 
@@ -226,6 +228,30 @@ The Centreon user account used by this server requires access to the Centreon RE
 - **Platform status**: administrator or operator access
 
 For a minimal read-only deployment, a standard monitoring user with API access is sufficient. For full tool coverage, an administrator account is recommended.
+
+## Doctor
+
+The `doctor` subcommand checks configuration, tests connectivity and credentials against the Centreon API, and reports the Centreon Web version:
+
+```bash
+centreon-mcp-go doctor
+```
+
+Sample output:
+
+```text
+config: ok (host https://centreon.example.com, transport stdio, auth mode env)
+connectivity: ok
+credentials: ok
+centreon version: 24.10.3
+doctor: healthy
+```
+
+Exit codes:
+- `0`: Healthy. Configuration is valid, connectivity and credentials are confirmed (or skipped in gateway mode), and the server is ready to run.
+- `1`: Configuration error. Required environment variables or secret files are missing, malformed, unreadable, or empty.
+- `2`: Unreachable. The Centreon platform cannot be reached (for example DNS failure, connection refused, TLS error, or non-auth HTTP error).
+- `3`: Bad credentials. The Centreon API rejected the configured credentials (HTTP 401 or 403). Note: an API token that authenticates successfully but lacks realtime-monitoring permissions also classifies as bad credentials (403).
 
 ## Development
 

--- a/config.go
+++ b/config.go
@@ -42,28 +42,47 @@ type Config struct {
 	AllowedHosts []string
 }
 
-// LoadConfig reads configuration from environment variables.
-func LoadConfig() (Config, error) {
-	cfg := Config{
-		Host:     os.Getenv("CENTREON_HOST"),
-		Username: os.Getenv("CENTREON_USERNAME"),
-		Password: os.Getenv("CENTREON_PASSWORD"),
-		Token:    os.Getenv("CENTREON_TOKEN"),
-		HTTPHost: os.Getenv("MCP_HTTP_HOST"),
+// loadCredentials resolves the password and token, preferring their _FILE
+// variants when set, and validates that the host and a usable credential
+// (a token, or a username plus password) are present.
+func loadCredentials(cfg *Config) error {
+	password, err := resolveSecretEnv("CENTREON_PASSWORD")
+	if err != nil {
+		return err
 	}
+	cfg.Password = password
+	token, err := resolveSecretEnv("CENTREON_TOKEN")
+	if err != nil {
+		return err
+	}
+	cfg.Token = token
 
 	if cfg.Host == "" {
-		return Config{}, fmt.Errorf("CENTREON_HOST environment variable is required")
+		return fmt.Errorf("CENTREON_HOST environment variable is required")
 	}
 
 	// Either token or username+password must be set
 	if cfg.Token == "" {
 		if cfg.Username == "" {
-			return Config{}, fmt.Errorf("CENTREON_USERNAME environment variable is required (or set CENTREON_TOKEN)")
+			return fmt.Errorf("CENTREON_USERNAME environment variable is required (or set CENTREON_TOKEN)")
 		}
 		if cfg.Password == "" {
-			return Config{}, fmt.Errorf("CENTREON_PASSWORD environment variable is required (or set CENTREON_TOKEN)")
+			return fmt.Errorf("CENTREON_PASSWORD environment variable is required (or set CENTREON_TOKEN)")
 		}
+	}
+	return nil
+}
+
+// LoadConfig reads configuration from environment variables.
+func LoadConfig() (Config, error) {
+	cfg := Config{
+		Host:     os.Getenv("CENTREON_HOST"),
+		Username: os.Getenv("CENTREON_USERNAME"),
+		HTTPHost: os.Getenv("MCP_HTTP_HOST"),
+	}
+
+	if err := loadCredentials(&cfg); err != nil {
+		return Config{}, err
 	}
 
 	cfg.Transport = envOr("MCP_TRANSPORT", transportStdio)
@@ -195,6 +214,45 @@ func parseBoolEnv(name string) (bool, error) {
 		return false, fmt.Errorf("invalid %s value %q: expected true/false", name, raw)
 	}
 	return v, nil
+}
+
+// resolveSecretEnv returns the value of the secret environment variable name,
+// preferring the file named by the <name>_FILE variant when that variant is
+// set. The file form (Docker and Kubernetes secrets convention) takes
+// precedence over the inline variable so a mounted secret cannot be shadowed
+// by a stale inline value. A set but missing, unreadable, or empty file is a
+// hard configuration error: failing fast beats authenticating with an empty
+// secret. The error names the variable and the file path but never the file
+// contents (CWE-532).
+func resolveSecretEnv(name string) (string, error) {
+	fileVar := name + "_FILE"
+	path := os.Getenv(fileVar)
+	if path == "" {
+		return os.Getenv(name), nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("%s: cannot read secret file: %w", fileVar, err)
+	}
+	secret := trimTrailingNewline(string(data))
+	if secret == "" {
+		return "", fmt.Errorf("%s: secret file %q is empty", fileVar, path)
+	}
+	return secret, nil
+}
+
+// trimTrailingNewline removes exactly one trailing line break, "\r\n" or "\n",
+// from s. Nothing else is trimmed: a secret may legitimately end in a space,
+// a tab, or even a bare carriage return, so only the newline that an editor
+// or an echo appends is stripped, and only one of them.
+func trimTrailingNewline(s string) string {
+	if after, ok := strings.CutSuffix(s, "\r\n"); ok {
+		return after
+	}
+	if after, ok := strings.CutSuffix(s, "\n"); ok {
+		return after
+	}
+	return s
 }
 
 // gatewayMode reports whether the server runs in HTTP gateway mode: http

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -11,6 +13,8 @@ func TestLoadConfig_Valid(t *testing.T) {
 	t.Setenv("CENTREON_USERNAME", "admin")
 	t.Setenv("CENTREON_PASSWORD", "secret")
 	t.Setenv("CENTREON_TOKEN", "tok123")
+	t.Setenv("CENTREON_PASSWORD_FILE", "")
+	t.Setenv("CENTREON_TOKEN_FILE", "")
 	t.Setenv("CENTREON_ALLOW_SELF_SIGNED", "true")
 	t.Setenv("MCP_TRANSPORT", "http")
 	t.Setenv("MCP_HTTP_PORT", "9090")
@@ -60,6 +64,8 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	t.Setenv("CENTREON_USERNAME", "admin")
 	t.Setenv("CENTREON_PASSWORD", "secret")
 	t.Setenv("CENTREON_TOKEN", "")
+	t.Setenv("CENTREON_PASSWORD_FILE", "")
+	t.Setenv("CENTREON_TOKEN_FILE", "")
 	t.Setenv("CENTREON_ALLOW_SELF_SIGNED", "")
 	t.Setenv("CENTREON_ALLOW_HTTP", "")
 	t.Setenv("MCP_READ_ONLY", "")
@@ -107,6 +113,8 @@ func TestLoadConfig_ReadOnly(t *testing.T) {
 		t.Setenv("CENTREON_USERNAME", "admin")
 		t.Setenv("CENTREON_PASSWORD", "secret")
 		t.Setenv("CENTREON_TOKEN", "")
+		t.Setenv("CENTREON_PASSWORD_FILE", "")
+		t.Setenv("CENTREON_TOKEN_FILE", "")
 	}
 
 	t.Run("true enables read-only", func(t *testing.T) {
@@ -149,6 +157,8 @@ func TestLoadConfig_MissingRequired(t *testing.T) {
 			t.Setenv("CENTREON_USERNAME", tt.username)
 			t.Setenv("CENTREON_PASSWORD", tt.password)
 			t.Setenv("CENTREON_TOKEN", "")
+			t.Setenv("CENTREON_PASSWORD_FILE", "")
+			t.Setenv("CENTREON_TOKEN_FILE", "")
 
 			_, err := LoadConfig()
 			if err == nil {
@@ -166,6 +176,8 @@ func TestLoadConfig_TokenOnly(t *testing.T) {
 	t.Setenv("CENTREON_USERNAME", "")
 	t.Setenv("CENTREON_PASSWORD", "")
 	t.Setenv("CENTREON_TOKEN", "my-api-token")
+	t.Setenv("CENTREON_PASSWORD_FILE", "")
+	t.Setenv("CENTREON_TOKEN_FILE", "")
 
 	cfg, err := LoadConfig()
 	if err != nil {
@@ -174,6 +186,206 @@ func TestLoadConfig_TokenOnly(t *testing.T) {
 	if cfg.Token != "my-api-token" {
 		t.Errorf("expected Token my-api-token, got %q", cfg.Token)
 	}
+}
+
+type secretFileCase struct {
+	name         string
+	fileContents string
+	passwordVar  string
+	tokenVar     string
+	usePassFile  bool
+	useTokenFile bool
+	wantPassword string
+	wantToken    string
+}
+
+func runSecretFileTest(t *testing.T, tt *secretFileCase) {
+	t.Helper()
+	t.Setenv("CENTREON_HOST", "https://centreon.example.com")
+	t.Setenv("CENTREON_USERNAME", "admin")
+	t.Setenv("CENTREON_PASSWORD", tt.passwordVar)
+	t.Setenv("CENTREON_TOKEN", tt.tokenVar)
+	t.Setenv("CENTREON_PASSWORD_FILE", "")
+	t.Setenv("CENTREON_TOKEN_FILE", "")
+
+	if tt.useTokenFile {
+		t.Setenv("CENTREON_USERNAME", "")
+		t.Setenv("CENTREON_PASSWORD", "")
+		t.Setenv("CENTREON_TOKEN", "")
+	}
+
+	if tt.usePassFile {
+		path := filepath.Join(t.TempDir(), "passwd")
+		if err := os.WriteFile(path, []byte(tt.fileContents), 0o600); err != nil {
+			t.Fatalf("write temp secret: %v", err)
+		}
+		t.Setenv("CENTREON_PASSWORD_FILE", path)
+	}
+	if tt.useTokenFile {
+		path := filepath.Join(t.TempDir(), "token")
+		if err := os.WriteFile(path, []byte(tt.fileContents), 0o600); err != nil {
+			t.Fatalf("write temp secret: %v", err)
+		}
+		t.Setenv("CENTREON_TOKEN_FILE", path)
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if tt.wantPassword != "" && cfg.Password != tt.wantPassword {
+		t.Errorf("expected Password %q, got %q", tt.wantPassword, cfg.Password)
+	}
+	if tt.wantToken != "" && cfg.Token != tt.wantToken {
+		t.Errorf("expected Token %q, got %q", tt.wantToken, cfg.Token)
+	}
+}
+
+func TestLoadConfig_SecretFile(t *testing.T) {
+	tests := []secretFileCase{
+		{
+			name:         "password from file, inline unset",
+			fileContents: "filepw\n",
+			usePassFile:  true,
+			wantPassword: "filepw",
+		},
+		{
+			name:         "file precedence over inline",
+			fileContents: "filepw",
+			passwordVar:  "inlinepw",
+			usePassFile:  true,
+			wantPassword: "filepw",
+		},
+		{
+			name:         "token from file satisfies requirement",
+			fileContents: "filetok\n",
+			useTokenFile: true,
+			wantToken:    "filetok",
+		},
+		{
+			name:         "trailing LF trimmed",
+			fileContents: "tok\n",
+			useTokenFile: true,
+			wantToken:    "tok",
+		},
+		{
+			name:         "trailing CRLF trimmed",
+			fileContents: "tok\r\n",
+			useTokenFile: true,
+			wantToken:    "tok",
+		},
+		{
+			name:         "only one newline trimmed",
+			fileContents: "tok\n\n",
+			useTokenFile: true,
+			wantToken:    "tok\n",
+		},
+		{
+			name:         "trailing space preserved",
+			fileContents: "tok \n",
+			useTokenFile: true,
+			wantToken:    "tok ",
+		},
+		{
+			name:         "bare trailing CR preserved",
+			fileContents: "tok\r",
+			useTokenFile: true,
+			wantToken:    "tok\r",
+		},
+		{
+			name:         "unset _FILE leaves inline behavior",
+			passwordVar:  "inlinepw",
+			wantPassword: "inlinepw",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runSecretFileTest(t, &tt)
+		})
+	}
+}
+
+func testSecretFileMissing(t *testing.T) {
+	t.Setenv("CENTREON_HOST", "https://centreon.example.com")
+	t.Setenv("CENTREON_USERNAME", "admin")
+	t.Setenv("CENTREON_PASSWORD", "")
+	t.Setenv("CENTREON_TOKEN", "")
+	t.Setenv("CENTREON_TOKEN_FILE", "")
+	absentPath := filepath.Join(t.TempDir(), "absent")
+	t.Setenv("CENTREON_PASSWORD_FILE", absentPath)
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for missing secret file, got nil")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "CENTREON_PASSWORD_FILE") {
+		t.Errorf("expected error to name variable CENTREON_PASSWORD_FILE, got: %v", err)
+	}
+	if !strings.Contains(errStr, absentPath) {
+		t.Errorf("expected error to contain path %q, got: %v", absentPath, err)
+	}
+	if !strings.Contains(errStr, "cannot read secret file") {
+		t.Errorf("expected error to contain 'cannot read secret file', got: %v", err)
+	}
+}
+
+func testSecretFileEmpty(t *testing.T) {
+	t.Setenv("CENTREON_HOST", "https://centreon.example.com")
+	t.Setenv("CENTREON_USERNAME", "")
+	t.Setenv("CENTREON_PASSWORD", "")
+	t.Setenv("CENTREON_TOKEN", "")
+	t.Setenv("CENTREON_PASSWORD_FILE", "")
+	emptyFile := filepath.Join(t.TempDir(), "empty_token")
+	if err := os.WriteFile(emptyFile, []byte("\n"), 0o600); err != nil {
+		t.Fatalf("write empty temp secret: %v", err)
+	}
+	t.Setenv("CENTREON_TOKEN_FILE", emptyFile)
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected error for empty secret file, got nil")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "CENTREON_TOKEN_FILE") {
+		t.Errorf("expected error to name variable CENTREON_TOKEN_FILE, got: %v", err)
+	}
+	if !strings.Contains(errStr, emptyFile) {
+		t.Errorf("expected error to contain path %q, got: %v", emptyFile, err)
+	}
+	if !strings.Contains(errStr, "is empty") {
+		t.Errorf("expected error to contain 'is empty', got: %v", err)
+	}
+}
+
+func testSecretFileNeverLeaks(t *testing.T) {
+	const leakSecret = "leakmarker-secret"
+	t.Setenv("CENTREON_HOST", "https://centreon.example.com")
+	t.Setenv("CENTREON_USERNAME", "admin")
+	t.Setenv("CENTREON_PASSWORD", "")
+	t.Setenv("CENTREON_TOKEN", "")
+	t.Setenv("CENTREON_TOKEN_FILE", "")
+	path := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte(leakSecret+"\n"), 0o600); err != nil {
+		t.Fatalf("write temp secret: %v", err)
+	}
+	t.Setenv("CENTREON_PASSWORD_FILE", path)
+	t.Setenv("MCP_HTTP_PORT", "invalid-port")
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("expected port parsing error, got nil")
+	}
+	if strings.Contains(err.Error(), leakSecret) {
+		t.Errorf("error leaked secret file contents: %v", err)
+	}
+}
+
+func TestLoadConfig_SecretFileErrors(t *testing.T) {
+	t.Run("missing file", testSecretFileMissing)
+	t.Run("empty file", testSecretFileEmpty)
+	t.Run("secret never leaks", testSecretFileNeverLeaks)
 }
 
 func TestLoadConfig_AllowedHosts(t *testing.T) {

--- a/doctor.go
+++ b/doctor.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	centreon "github.com/tphakala/centreon-go-client/v2"
+	"github.com/tphakala/centreon-mcp-go/internal/redact"
+)
+
+const (
+	doctorExitHealthy        = 0
+	doctorExitConfigError    = 1
+	doctorExitUnreachable    = 2
+	doctorExitBadCredentials = 3
+)
+
+// runDoctor implements the "doctor" subcommand: load config, build the same
+// guarded HTTP client the server uses, verify connectivity and credentials,
+// and report the Centreon version. It prints one line per check to out and
+// returns the process exit code. It never prints a password or token: doctor
+// formats its own host lines through displayHost (which strips all userinfo), a
+// config-load failure is surfaced as LoadConfig returns it (which never carries
+// a password or token, though a host it names keeps its username via safeHost),
+// and upstream request errors are classified through redact.Reason and the typed
+// HTTPStatus field.
+func runDoctor(ctx context.Context, out io.Writer) int {
+	cfg, err := LoadConfig()
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "config: FAIL: %v\n", err)
+		_, _ = fmt.Fprintln(out, "doctor: unhealthy")
+		return doctorExitConfigError
+	}
+	httpClient, err := newHTTPClient(cfg.AllowSelfSigned)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "config: FAIL: creating HTTP client: %v\n", err)
+		_, _ = fmt.Fprintln(out, "doctor: unhealthy")
+		return doctorExitConfigError
+	}
+	return doctorReport(ctx, &cfg, httpClient, out)
+}
+
+// doctorReport runs the connectivity and credential checks against an already
+// loaded config. Split from runDoctor so tests can inject a config and a
+// transport-faked HTTP client without touching the environment.
+func doctorReport(ctx context.Context, cfg *Config, httpClient *http.Client, out io.Writer) int {
+	_, _ = fmt.Fprintf(out, "config: ok (host %s, transport %s, auth mode %s)\n", displayHost(cfg.Host), cfg.Transport, cfg.AuthMode)
+
+	if gatewayMode(cfg) {
+		_, _ = fmt.Fprintln(out, "connectivity: skipped (gateway mode: credentials arrive per request)")
+		_, _ = fmt.Fprintln(out, "credentials: skipped (gateway mode)")
+		_, _ = fmt.Fprintln(out, "doctor: healthy (config only)")
+		return doctorExitHealthy
+	}
+
+	client, err := newCentreonClient(cfg.Host, cfg, nil, httpClient)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "config: FAIL: cannot create client for host %s: %s\n", displayHost(cfg.Host), redact.Reason(err))
+		_, _ = fmt.Fprintln(out, "doctor: unhealthy")
+		return doctorExitConfigError
+	}
+
+	var authErr error
+	if cfg.Token == "" {
+		authErr = client.Login(ctx)
+		if authErr == nil {
+			defer logoutClientBounded(ctx, client, slog.New(slog.DiscardHandler))
+		}
+	} else {
+		authErr = checkCredentials(ctx, client)
+	}
+
+	if authErr != nil {
+		if isAuthRejected(authErr) {
+			_, _ = fmt.Fprintln(out, "connectivity: ok (API reached)")
+			_, _ = fmt.Fprintf(out, "credentials: FAIL: %s\n", redact.Reason(authErr))
+			_, _ = fmt.Fprintln(out, "doctor: unhealthy")
+			return doctorExitBadCredentials
+		}
+		_, _ = fmt.Fprintf(out, "connectivity: FAIL: %s\n", redact.Reason(authErr))
+		_, _ = fmt.Fprintln(out, "credentials: skipped (platform unreachable)")
+		_, _ = fmt.Fprintln(out, "doctor: unhealthy")
+		return doctorExitUnreachable
+	}
+	_, _ = fmt.Fprintln(out, "connectivity: ok")
+	_, _ = fmt.Fprintln(out, "credentials: ok")
+
+	if versions, err := client.Platform.Versions(ctx); err != nil {
+		_, _ = fmt.Fprintf(out, "centreon version: unavailable (%s)\n", redact.Reason(err))
+	} else {
+		_, _ = fmt.Fprintf(out, "centreon version: %s\n", versions.Web.Version)
+	}
+	_, _ = fmt.Fprintln(out, "doctor: healthy")
+	return doctorExitHealthy
+}
+
+// isAuthRejected reports whether err is an authentication rejection from the
+// Centreon API (HTTP 401 or 403). It reads only the trusted HTTPStatus
+// integer of a typed *centreon.APIError, never error text, the same
+// fail-closed discipline as internal/redact.Reason and isNotFoundStatus, so
+// it cannot leak a credential and an unknown error classifies as unreachable
+// rather than as a credential verdict.
+func isAuthRejected(err error) bool {
+	if apiErr, ok := errors.AsType[*centreon.APIError](err); ok {
+		return apiErr.HTTPStatus == http.StatusUnauthorized || apiErr.HTTPStatus == http.StatusForbidden
+	}
+	return false
+}

--- a/doctor_test.go
+++ b/doctor_test.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDoctorReport_HealthyTokenMode(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	mux.HandleFunc("GET /centreon/api/latest/platform/versions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"web": map[string]any{
+				"version": "24.10.3",
+				"major":   "24",
+				"minor":   "10",
+				"fix":     "3",
+			},
+			"modules": map[string]any{},
+			"widgets": map[string]any{},
+		})
+	})
+	fake := httptest.NewServer(mux)
+	defer fake.Close()
+
+	cfg := &Config{
+		Host:      fake.URL,
+		Token:     "tok",
+		AllowHTTP: true,
+		Transport: transportStdio,
+		AuthMode:  authModeEnv,
+	}
+
+	var buf bytes.Buffer
+	code := doctorReport(t.Context(), cfg, fake.Client(), &buf)
+	if code != doctorExitHealthy {
+		t.Fatalf("expected exit code %d, got %d. Output:\n%s", doctorExitHealthy, code, buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "config: ok") {
+		t.Errorf("expected output to contain 'config: ok', got:\n%s", out)
+	}
+	if !strings.Contains(out, "connectivity: ok") {
+		t.Errorf("expected output to contain 'connectivity: ok', got:\n%s", out)
+	}
+	if !strings.Contains(out, "credentials: ok") {
+		t.Errorf("expected output to contain 'credentials: ok', got:\n%s", out)
+	}
+	if !strings.Contains(out, "centreon version: 24.10.3") {
+		t.Errorf("expected output to contain 'centreon version: 24.10.3', got:\n%s", out)
+	}
+	if !strings.Contains(out, "doctor: healthy") {
+		t.Errorf("expected output to contain 'doctor: healthy', got:\n%s", out)
+	}
+}
+
+func TestDoctorReport_HealthyPasswordMode(t *testing.T) {
+	var logoutCalled atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /centreon/api/latest/login", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"security": map[string]any{
+				"token": "tok-1",
+			},
+		})
+	})
+	mux.HandleFunc("GET /centreon/api/latest/logout", func(w http.ResponseWriter, _ *http.Request) {
+		logoutCalled.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("GET /centreon/api/latest/platform/versions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"web": map[string]any{
+				"version": "24.10.3",
+				"major":   "24",
+				"minor":   "10",
+				"fix":     "3",
+			},
+			"modules": map[string]any{},
+			"widgets": map[string]any{},
+		})
+	})
+	fake := httptest.NewServer(mux)
+	defer fake.Close()
+
+	cfg := &Config{
+		Host:      fake.URL,
+		Username:  "admin",
+		Password:  "secret",
+		AllowHTTP: true,
+		Transport: transportStdio,
+		AuthMode:  authModeEnv,
+	}
+
+	var buf bytes.Buffer
+	code := doctorReport(t.Context(), cfg, fake.Client(), &buf)
+	if code != doctorExitHealthy {
+		t.Fatalf("expected exit code %d, got %d. Output:\n%s", doctorExitHealthy, code, buf.String())
+	}
+	if !logoutCalled.Load() {
+		t.Error("expected logout to be called during healthy password doctor check")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "doctor: healthy") {
+		t.Errorf("expected output to contain 'doctor: healthy', got:\n%s", out)
+	}
+}
+
+func runBadCredentialsTest(t *testing.T, statusCode int, useToken bool) {
+	t.Helper()
+	mux := http.NewServeMux()
+	if useToken {
+		mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(statusCode)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code":    statusCode,
+				"message": "auth error",
+			})
+		})
+	} else {
+		mux.HandleFunc("POST /centreon/api/latest/login", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(statusCode)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code":    statusCode,
+				"message": "auth error",
+			})
+		})
+	}
+	fake := httptest.NewServer(mux)
+	defer fake.Close()
+
+	cfg := &Config{
+		Host:      fake.URL,
+		AllowHTTP: true,
+		Transport: transportStdio,
+		AuthMode:  authModeEnv,
+	}
+	if useToken {
+		cfg.Token = "bad-tok"
+	} else {
+		cfg.Username = "admin"
+		cfg.Password = "bad-pass"
+	}
+
+	var buf bytes.Buffer
+	code := doctorReport(t.Context(), cfg, fake.Client(), &buf)
+	if code != doctorExitBadCredentials {
+		t.Fatalf("expected exit code %d, got %d. Output:\n%s", doctorExitBadCredentials, code, buf.String())
+	}
+
+	out := buf.String()
+	wantReason := fmt.Sprintf("credentials: FAIL: centreon API error (HTTP %d)", statusCode)
+	if !strings.Contains(out, wantReason) {
+		t.Errorf("expected output to contain %q, got:\n%s", wantReason, out)
+	}
+	if !strings.Contains(out, "connectivity: ok (API reached)") {
+		t.Errorf("expected output to contain 'connectivity: ok (API reached)', got:\n%s", out)
+	}
+	if !strings.Contains(out, "doctor: unhealthy") {
+		t.Errorf("expected output to contain 'doctor: unhealthy', got:\n%s", out)
+	}
+}
+
+func TestDoctorReport_BadCredentials(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		useToken   bool
+	}{
+		{"token mode 401", http.StatusUnauthorized, true},
+		{"token mode 403", http.StatusForbidden, true},
+		{"password mode 401", http.StatusUnauthorized, false},
+		{"password mode 403", http.StatusForbidden, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runBadCredentialsTest(t, tt.statusCode, tt.useToken)
+		})
+	}
+}
+
+func TestDoctorReport_Unreachable(t *testing.T) {
+	cfg := &Config{
+		Host:      "https://unreachable.example.com",
+		Token:     "tok",
+		Transport: transportStdio,
+		AuthMode:  authModeEnv,
+	}
+
+	var buf bytes.Buffer
+	code := doctorReport(t.Context(), cfg, failDNSClient(), &buf)
+	if code != doctorExitUnreachable {
+		t.Fatalf("expected exit code %d, got %d. Output:\n%s", doctorExitUnreachable, code, buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "connectivity: FAIL:") {
+		t.Errorf("expected output to contain 'connectivity: FAIL:', got:\n%s", out)
+	}
+	if !strings.Contains(out, "credentials: skipped (platform unreachable)") {
+		t.Errorf("expected output to contain 'credentials: skipped (platform unreachable)', got:\n%s", out)
+	}
+	if !strings.Contains(out, "doctor: unhealthy") {
+		t.Errorf("expected output to contain 'doctor: unhealthy', got:\n%s", out)
+	}
+}
+
+func TestDoctorReport_VersionUnavailableStaysHealthy(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	mux.HandleFunc("GET /centreon/api/latest/platform/versions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code":    404,
+			"message": "not found",
+		})
+	})
+	fake := httptest.NewServer(mux)
+	defer fake.Close()
+
+	cfg := &Config{
+		Host:      fake.URL,
+		Token:     "tok",
+		AllowHTTP: true,
+		Transport: transportStdio,
+		AuthMode:  authModeEnv,
+	}
+
+	var buf bytes.Buffer
+	code := doctorReport(t.Context(), cfg, fake.Client(), &buf)
+	if code != doctorExitHealthy {
+		t.Fatalf("expected exit code %d, got %d. Output:\n%s", doctorExitHealthy, code, buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "centreon version: unavailable") {
+		t.Errorf("expected output to contain 'centreon version: unavailable', got:\n%s", out)
+	}
+	if !strings.Contains(out, "doctor: healthy") {
+		t.Errorf("expected output to contain 'doctor: healthy', got:\n%s", out)
+	}
+}
+
+func TestDoctorReport_NeverPrintsSecret(t *testing.T) {
+	cfg := &Config{
+		Host:      misparsedHost,
+		Token:     leakMarker,
+		Transport: transportStdio,
+		AuthMode:  authModeEnv,
+	}
+
+	var buf bytes.Buffer
+	doctorReport(t.Context(), cfg, failDNSClient(), &buf)
+
+	out := buf.String()
+	if strings.Contains(out, leakMarker) {
+		t.Errorf("doctor output leaked secret token (CWE-532): %s", out)
+	}
+	if strings.Contains(out, "admin:1234") {
+		t.Errorf("doctor output leaked misparsedHost userinfo: %s", out)
+	}
+}
+
+func TestDoctorReport_GatewayModeSkipsChecks(t *testing.T) {
+	cfg := &Config{
+		Host:      "https://placeholder.example",
+		Transport: transportHTTP,
+		AuthMode:  authModeGateway,
+		Token:     "tok",
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			t.Fatal("unexpected HTTP request made in gateway mode")
+			return nil, errors.New("unexpected HTTP request made in gateway mode")
+		}),
+	}
+
+	var buf bytes.Buffer
+	code := doctorReport(t.Context(), cfg, client, &buf)
+	if code != doctorExitHealthy {
+		t.Fatalf("expected exit code %d, got %d. Output:\n%s", doctorExitHealthy, code, buf.String())
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "connectivity: skipped (gateway mode: credentials arrive per request)") {
+		t.Errorf("expected connectivity skipped line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "credentials: skipped (gateway mode)") {
+		t.Errorf("expected credentials skipped line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "doctor: healthy (config only)") {
+		t.Errorf("expected 'doctor: healthy (config only)', got:\n%s", out)
+	}
+}
+
+func TestRunDoctor_ConfigErrorExitsOne(t *testing.T) {
+	t.Setenv("CENTREON_HOST", "")
+	t.Setenv("CENTREON_USERNAME", "")
+	t.Setenv("CENTREON_PASSWORD", "")
+	t.Setenv("CENTREON_TOKEN", "")
+	t.Setenv("CENTREON_PASSWORD_FILE", "")
+	t.Setenv("CENTREON_TOKEN_FILE", "")
+
+	var buf bytes.Buffer
+	code := runDoctor(t.Context(), &buf)
+	if code != doctorExitConfigError {
+		t.Fatalf("expected exit code %d, got %d", doctorExitConfigError, code)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "config: FAIL:") {
+		t.Errorf("expected output to start with 'config: FAIL:', got:\n%s", out)
+	}
+}
+
+func TestRunDoctor_TokenFromFileHealthy(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-AUTH-TOKEN"); got != "tok" {
+			t.Errorf("expected X-AUTH-TOKEN 'tok', got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	mux.HandleFunc("GET /centreon/api/latest/platform/versions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"web": map[string]any{
+				"version": "24.10.3",
+				"major":   "24",
+				"minor":   "10",
+				"fix":     "3",
+			},
+			"modules": map[string]any{},
+			"widgets": map[string]any{},
+		})
+	})
+	fake := httptest.NewServer(mux)
+	defer fake.Close()
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("tok\n"), 0o600); err != nil {
+		t.Fatalf("write temp token: %v", err)
+	}
+
+	t.Setenv("CENTREON_HOST", fake.URL)
+	t.Setenv("CENTREON_ALLOW_HTTP", "true")
+	t.Setenv("CENTREON_USERNAME", "")
+	t.Setenv("CENTREON_PASSWORD", "")
+	t.Setenv("CENTREON_TOKEN", "")
+	t.Setenv("CENTREON_PASSWORD_FILE", "")
+	t.Setenv("CENTREON_TOKEN_FILE", tokenPath)
+	t.Setenv("MCP_TRANSPORT", "stdio")
+	t.Setenv("AUTH_MODE", "env")
+
+	var buf bytes.Buffer
+	code := runDoctor(t.Context(), &buf)
+	if code != doctorExitHealthy {
+		t.Fatalf("expected exit code %d, got %d. Output:\n%s", doctorExitHealthy, code, buf.String())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,12 @@ import (
 var version = "dev"
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "doctor" {
+		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		code := runDoctor(ctx, os.Stdout)
+		cancel()
+		os.Exit(code)
+	}
 	if err := runMain(); err != nil {
 		os.Exit(1)
 	}

--- a/server.go
+++ b/server.go
@@ -180,6 +180,18 @@ func newCentreonClient(host string, cfg *Config, logger *slog.Logger, httpClient
 	return centreon.NewClient(host, opts...)
 }
 
+// checkCredentials performs the cheapest authenticated read against the
+// Centreon API, GET /monitoring/hosts/status, the same call the
+// centreon_connection_test tool uses. It confirms in one round trip that the
+// platform is reachable and the configured credential is accepted. It returns
+// the raw client error so each caller can classify it for its own sink:
+// redact.Reason for the startup error paths, the typed HTTPStatus check for
+// the doctor subcommand. Callers must not print the raw error (CWE-532).
+func checkCredentials(ctx context.Context, client *centreon.Client) error {
+	_, err := client.MonitoringHosts.StatusCounts(ctx)
+	return err
+}
+
 // warnIfAllowlistIneffective emits a startup warning when CENTREON_ALLOWED_HOSTS
 // is configured but the effective mode will never consult it. The allowlist is
 // only enforced in gateway mode (http transport with gateway auth); in every
@@ -236,6 +248,16 @@ func runStdio(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient 
 		}
 		defer logoutClientBounded(ctx, client, logger)
 		logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
+	} else {
+		// Token mode performs no login, so an invalid or expired token would
+		// otherwise surface only on the first tool call. Validate at boot and
+		// fail fast (issue #82) via the cheapest authenticated read
+		// (StatusCounts); this also exercises realtime-monitoring access, so it
+		// is slightly stricter than the password path's plain Login.
+		if err := checkCredentials(ctx, client); err != nil {
+			return fmt.Errorf("centreon token validation failed (host %s): %s", safeHost(cfg.Host), redact.Reason(err))
+		}
+		logger.Info("centreon token validated", "host", safeHost(cfg.Host))
 	}
 
 	s := buildServer(client, logger, displayHost(cfg.Host), cfg.ReadOnly)
@@ -285,6 +307,16 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 				return fmt.Errorf("centreon login failed (host %s): %s", safeHost(cfg.Host), redact.Reason(err))
 			}
 			logger.Info("centreon client authenticated", "host", safeHost(cfg.Host))
+		} else {
+			// Token mode performs no login, so an invalid or expired token would
+			// otherwise surface only on the first tool call. Validate at boot and
+			// fail fast (issue #82) via the cheapest authenticated read
+			// (StatusCounts); this also exercises realtime-monitoring access, so it
+			// is slightly stricter than the password path's plain Login.
+			if err := checkCredentials(ctx, client); err != nil {
+				return fmt.Errorf("centreon token validation failed (host %s): %s", safeHost(cfg.Host), redact.Reason(err))
+			}
+			logger.Info("centreon token validated", "host", safeHost(cfg.Host))
 		}
 		sharedClient = client
 		envDisplayHost = displayHost(cfg.Host)

--- a/server_redact_test.go
+++ b/server_redact_test.go
@@ -75,6 +75,26 @@ func TestRunStdio_LoginErrorRedacted(t *testing.T) {
 	}
 }
 
+// TestRunStdio_TokenPreflightErrorRedacted pins that a failed startup token
+// preflight does not carry the credential out through the error returned to main
+// (CWE-532, #63, #82).
+func TestRunStdio_TokenPreflightErrorRedacted(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.DiscardHandler)
+	cfg := &Config{Host: misparsedHost, Token: "tok"}
+
+	err := runStdio(t.Context(), cfg, logger, failDNSClient(), nil)
+	if err == nil {
+		t.Fatal("want a preflight error, got nil")
+	}
+	if strings.Contains(err.Error(), leakMarker) {
+		t.Errorf("token preflight error leaked credential (CWE-532): %v", err)
+	}
+	if !strings.Contains(err.Error(), "centreon token validation failed") {
+		t.Errorf("want the token-validation-failure wrap to stay identifiable, got: %v", err)
+	}
+}
+
 // TestLogoutCachedToken_LogNeverLeaksCredential pins that the gateway
 // token-logout Debug sinks (#63) do not print the credential-bearing host URL.
 // logoutCachedToken builds its client with a nil logger, so the buffer holds

--- a/server_test.go
+++ b/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -1140,5 +1141,175 @@ func TestRunStdio_ToolResponseReportsRedactedHost(t *testing.T) {
 	case <-errCh:
 	case <-time.After(15 * time.Second):
 		t.Fatal("runStdio did not return within 15s after context cancel")
+	}
+}
+
+func TestRunStdio_TokenPreflightRejectsBadToken(t *testing.T) {
+	fakeMux := http.NewServeMux()
+	fakeMux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code":    401,
+			"message": "invalid token",
+		})
+	})
+	fake := httptest.NewServer(fakeMux)
+	defer fake.Close()
+
+	cfg := &Config{
+		Host:      fake.URL,
+		Token:     "bad-token",
+		AllowHTTP: true,
+	}
+
+	err := runStdio(t.Context(), cfg, slog.New(slog.DiscardHandler), nil, nil)
+	if err == nil {
+		t.Fatal("expected error on bad token preflight, got nil")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "centreon token validation failed") {
+		t.Errorf("expected error to contain 'centreon token validation failed', got: %v", err)
+	}
+	if !strings.Contains(errStr, "HTTP 401") {
+		t.Errorf("expected error to contain 'HTTP 401', got: %v", err)
+	}
+	if strings.Contains(errStr, "bad-token") {
+		t.Errorf("error leaked token (CWE-532): %v", err)
+	}
+}
+
+func TestRunStdio_TokenPreflightSuccessProceeds(t *testing.T) {
+	var statusHits atomic.Int32
+
+	fakeMux := http.NewServeMux()
+	fakeMux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		statusHits.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	fake := httptest.NewServer(fakeMux)
+	defer fake.Close()
+
+	cfg := &Config{
+		Host:      fake.URL,
+		Token:     "valid-tok",
+		Transport: transportStdio,
+		AllowHTTP: true,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	errCh := make(chan error, 1)
+	go func() { errCh <- runStdio(ctx, cfg, slog.New(slog.DiscardHandler), nil, serverTransport) }()
+
+	c := mcp.NewClient(&mcp.Implementation{Name: "preflight-test", Version: "0"}, nil)
+	cs, err := c.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	_ = cs.Close()
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("runStdio returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("runStdio did not return within 15s after context cancel")
+	}
+
+	if got := statusHits.Load(); got != 1 {
+		t.Errorf("expected status endpoint to be called exactly once during preflight, got %d", got)
+	}
+}
+
+func TestRunHTTP_EnvTokenPreflightRejectsBadToken(t *testing.T) {
+	fakeMux := http.NewServeMux()
+	fakeMux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code":    401,
+			"message": "invalid token",
+		})
+	})
+	fake := httptest.NewServer(fakeMux)
+	defer fake.Close()
+
+	port := freePort(t)
+	cfg := &Config{
+		Host:      fake.URL,
+		Transport: transportHTTP,
+		AuthMode:  authModeEnv,
+		Token:     "bad-token",
+		AllowHTTP: true,
+		HTTPHost:  "127.0.0.1",
+		HTTPPort:  port,
+	}
+
+	err := runHTTP(t.Context(), cfg, slog.New(slog.DiscardHandler), nil)
+	if err == nil {
+		t.Fatal("expected error on bad token preflight, got nil")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "centreon token validation failed") {
+		t.Errorf("expected error to contain 'centreon token validation failed', got: %v", err)
+	}
+	if strings.Contains(errStr, "bad-token") {
+		t.Errorf("error leaked token (CWE-532): %v", err)
+	}
+}
+
+func TestRunHTTP_GatewayModeSkipsStartupPreflight(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	var statusHits, logins atomic.Int32
+
+	fakeMux := http.NewServeMux()
+	fakeMux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		statusHits.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	fakeMux.HandleFunc("POST /centreon/api/latest/login", func(w http.ResponseWriter, _ *http.Request) {
+		n := logins.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"security": map[string]any{"token": fmt.Sprintf("tok-%d", n)}})
+	})
+	fake := httptest.NewServer(fakeMux)
+	defer fake.Close()
+
+	port := freePort(t)
+	cfg := &Config{
+		Host:      fake.URL,
+		Transport: transportHTTP,
+		AuthMode:  authModeGateway,
+		HTTPHost:  "127.0.0.1",
+		HTTPPort:  port,
+		AllowHTTP: true,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- runHTTP(ctx, cfg, logger, nil) }()
+
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+	waitForHealth(t, base+"/health")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runHTTP returned error on shutdown: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("runHTTP did not return within 15s after context cancel")
+	}
+
+	if got := statusHits.Load(); got != 0 {
+		t.Errorf("gateway mode should not hit status endpoint on startup, got %d hits", got)
+	}
+	if got := logins.Load(); got != 0 {
+		t.Errorf("gateway mode should not hit login endpoint on startup, got %d logins", got)
 	}
 }


### PR DESCRIPTION
Folds #84 (file-based `_FILE` secrets) and #82 (token-mode startup validation plus a `doctor` subcommand) into one change. Both are self-contained in this repo with no `centreon-go-client` dependency.

## #84: file-based secrets

`CENTREON_PASSWORD_FILE` and `CENTREON_TOKEN_FILE` read the secret from a mounted file (the Docker and Kubernetes secrets convention), keeping it out of the process environment where `/proc/<pid>/environ` exposes it. A `_FILE` variable takes precedence over its inline counterpart, exactly one trailing newline (`\n` or `\r\n`) is trimmed (other trailing whitespace is preserved, since a secret may legitimately end in a space), and a set but missing, unreadable, or empty file is a fail-fast configuration error that names the variable and path but never the contents. Resolution happens at the top of `LoadConfig`, so every downstream credential consumer sees the file-sourced value.

## #82: startup validation and doctor

Token mode previously did no validation at boot, so a bad or expired token first surfaced on the first tool call. It now performs the cheapest authenticated read (`GET /monitoring/hosts/status`, the same call `centreon_connection_test` uses) at startup in stdio and HTTP env-auth modes, matching password mode's existing login-at-boot. Like password mode, this means an unreachable platform now blocks startup rather than the server starting and failing on the first call. Gateway mode is unaffected, since credentials arrive per request there.

The new `centreon-mcp-go doctor` subcommand loads config, builds the same guarded HTTP client the server uses, verifies connectivity and credentials, reports the Centreon Web version, and exits `0` healthy, `1` config error, `2` unreachable, `3` bad credentials, so a container healthcheck or setup script can branch. Any non-`doctor` invocation still runs the server exactly as before.

## Redaction

Doctor formats its own host lines through `displayHost` (strips all userinfo); logs and config errors redact hosts via `safeHost` (password masked, username kept for grep, as elsewhere in the server); upstream errors are classified through `redact.Reason` and the typed `HTTPStatus` field, never by copying an error string. No password or token reaches a log, an error return, or doctor stdout on any path.

## Tests

Table-driven coverage for `_FILE` precedence, all trimming cases (LF, CRLF, one-newline-only, trailing space preserved, bare CR preserved), and the missing/empty/never-leaks error paths; token preflight accept and reject in both env transports plus the gateway-skip pin; and doctor's healthy, bad-credentials (401/403), unreachable, version-unavailable, never-prints-secret, and gateway-skip paths with exact exit codes. Every behavioral test was sabotage-verified.

## Review

Pre-push `/gate` (six review agents plus Gemini cross-validation) converged in one round with no Critical/High. The one Medium (doctor mixed `safeHost` and `displayHost` on its own stdout while its docstring claimed uniform `displayHost`) is fixed by making doctor's host output uniformly `displayHost`; three comment-accuracy overclaims are corrected. The transient-outage-blocks-startup behavior was kept deliberately, since #82 requires fail-fast on an unreachable configuration to match password mode, and is now documented explicitly. Remaining Low items are batched in #92.

Closes #84
Closes #82


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading passwords and tokens from files, with precedence rules and trailing-newline trimming.
  * Added a `doctor` command to validate configuration, connectivity, credentials, and platform version, with clear status and exit codes.
* **Bug Fixes**
  * Token authentication is now verified during startup, preventing services from starting with invalid credentials.
  * Configuration errors for missing or empty secret files are reported safely without exposing sensitive values.
* **Documentation**
  * Expanded configuration and `doctor` command guidance, including secret-file behavior and exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->