### PR TITLE
Harden the unauthenticated gateway path, normalize list output, fix resource_check idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   modes, failing fast on a bad or expired token. Like password-mode's existing
   login-at-boot, this means an unreachable platform now blocks startup instead
   of the server starting and failing on the first tool call. (#82)
+- In gateway (multi-tenant HTTP) mode, a caller-supplied `X-Centreon-Token` is now
+  validated against Centreon (a `/monitoring/hosts/status` read) before the
+  per-request server is built. A token that is invalid, expired, or lacks
+  realtime-monitoring read access is now rejected at connection time rather than
+  succeeding and then failing on the first tool call. This is the gateway analog of
+  the env and stdio token boot-validation above (#82). (#79)
 - The `github.com/tphakala/centreon-go-client` dependency is updated to v2.1.0.
   v2.0.0 adopted upstream fixes for tools this server already ships: downtime and
   token timestamps are truncated to whole seconds (Centreon 25.10 rejects
@@ -85,6 +91,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Centreon) with a precise "API route not present" hint via the client's
   `IsRouteNotFound` classifier; an ambiguous 404 keeps the previous "not found, or
   unsupported on this Centreon version" wording. (#50, #51, #88)
+- List tool results now always serialize `result` as a JSON array. Previously a
+  successful list whose underlying result was a nil slice (a 204 No Content, or a
+  body with `result: null` or no `result` field) serialized as `"result": null`,
+  forcing a client to special-case null; it is now `"result": []`. (#85)
+- `centreon_resource_check` no longer advertises `idempotentHint`. Forcing an
+  on-demand check schedules a fresh check on every call, so it is destructive but
+  not idempotent; a client honoring the hint could otherwise auto-retry and trigger
+  repeated checks. `centreon_resource_submit`, which overwrites to a fixed state,
+  keeps `idempotentHint`. (#91)
 
 ### Security
 
@@ -122,22 +137,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reachable of the two, since such a host passes startup validation and runs
   normally. It leaked through four paths, including a bracketed-IPv6 carve-out and
   a tail search that both looked for a raw `:` only (CWE-532). (#68, #75)
-- In gateway (multi-tenant HTTP) mode the caller-supplied `X-Centreon-Host` header
-  is now length-capped (2048 bytes) before it reaches host redaction, and the HTTP
-  server caps total request-header size at 64 KiB instead of Go's 1 MiB default.
-  Previously an unauthenticated request could send a ~1 MiB header that reached the
+- The HTTP server now caps total request-header size at 64 KiB instead of Go's
+  1 MiB default, in both env-auth and gateway HTTP transport. Additionally, in
+  gateway (multi-tenant HTTP) mode the caller-supplied `X-Centreon-Host` header is
+  length-capped (2048 bytes) before it reaches host redaction. Previously an
+  unauthenticated gateway request could send a ~1 MiB header that reached the
   credential-redaction path before any authentication check, costing tens of
   milliseconds and megabytes of allocation per request, an unauthenticated DoS
   lever. (#76)
 - In gateway mode a caller-supplied `X-Centreon-Token` is now validated against
   Centreon before the per-request tool registry is built, so an unauthenticated
   caller can no longer force that build (measured at tens of thousands of
-  allocations per request) with an arbitrary token. A token that fails validation is
-  now rejected when the connection is established rather than surfacing later on the
-  first tool call, and successful validations are cached for the token cache's
-  lifetime so a repeat caller pays no extra round-trip. The per-request registry
-  rebuild for already-valid callers is tracked as a separate performance
-  follow-up. (#79)
+  allocations per request) with an arbitrary token. Successful validations are
+  cached (until the token cache's TTL elapses or the entry is evicted) so a repeat
+  caller pays no extra round-trip. The per-request registry rebuild for
+  already-valid callers is tracked as a separate performance follow-up (#94). (#79)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reachable of the two, since such a host passes startup validation and runs
   normally. It leaked through four paths, including a bracketed-IPv6 carve-out and
   a tail search that both looked for a raw `:` only (CWE-532). (#68, #75)
+- In gateway (multi-tenant HTTP) mode the caller-supplied `X-Centreon-Host` header
+  is now length-capped (2048 bytes) before it reaches host redaction, and the HTTP
+  server caps total request-header size at 64 KiB instead of Go's 1 MiB default.
+  Previously an unauthenticated request could send a ~1 MiB header that reached the
+  credential-redaction path before any authentication check, costing tens of
+  milliseconds and megabytes of allocation per request, an unauthenticated DoS
+  lever. (#76)
+- In gateway mode a caller-supplied `X-Centreon-Token` is now validated against
+  Centreon before the per-request tool registry is built, so an unauthenticated
+  caller can no longer force that build (measured at tens of thousands of
+  allocations per request) with an arbitrary token. A token that fails validation is
+  now rejected when the connection is established rather than surfacing later on the
+  first tool call, and successful validations are cached for the token cache's
+  lifetime so a repeat caller pays no extra round-trip. The per-request registry
+  rebuild for already-valid callers is tracked as a separate performance
+  follow-up. (#79)
 
 ### Changed
 

--- a/server.go
+++ b/server.go
@@ -527,10 +527,11 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 // false if it fails. A successful validation is remembered in tokenCache so a repeat
 // caller does not pay an upstream round-trip per request; the entry uses an EMPTY
 // stored token as a "validated" sentinel. The empty value is deliberate: it is the
-// token PARAMETER that carries the cache key, and shutdown's Drain/logoutCachedToken
-// no-ops on an empty stored token, so this caller-owned API token is never logged
-// out from under its owner. Do not "simplify" by storing the token itself: that
-// would make shutdown try to log out a token we do not own.
+// token PARAMETER that carries the cache key, and at shutdown logoutCachedToken
+// no-ops on an empty stored token (Drain still returns the entry; only the logout
+// is skipped), so this caller-owned API token is never logged out from under its
+// owner. Do not "simplify" by storing the token itself: that would make shutdown
+// try to log out a token we do not own.
 func validateGatewayToken(ctx context.Context, tokenCache *TokenCache, client *centreon.Client, host, token string, logger *slog.Logger) bool {
 	if _, ok := tokenCache.Get(host, "", token); ok {
 		return true

--- a/server.go
+++ b/server.go
@@ -44,6 +44,23 @@ const (
 	tokenCacheTTL     = 50 * time.Minute
 	httpClientTimeout = 30 * time.Second
 
+	// maxHostHeaderBytes caps the length of the gateway X-Centreon-Host request
+	// header. In gateway mode that header is attacker-controlled and reaches the
+	// credential-redaction path (safeHost) before any authentication, so an
+	// unbounded value turns an unauthenticated request into an O(len) redaction
+	// cost (issue #76). A real Centreon base URL is a few hundred bytes. The value
+	// is sourced from maxCachedHostLen (token_cache.go), the existing bound on a
+	// retained host, so the two host-length limits share one source and cannot
+	// drift apart.
+	maxHostHeaderBytes = maxCachedHostLen
+	// maxHeaderBytes caps the total request-header size the HTTP server will parse,
+	// replacing net/http's 1 MiB default (http.DefaultMaxHeaderBytes) with a value
+	// 16x smaller. The MCP streamable-HTTP transport needs only a handful of small
+	// headers, so 64 KiB is generous; oversized headers get a 431 before any
+	// handler runs, so an unauthenticated caller cannot make the server buffer up to
+	// a megabyte per request (issue #76).
+	maxHeaderBytes = 64 << 10
+
 	// maxRedirects caps a redirect chain, matching net/http's default policy that
 	// noCrossHostRedirect replaces: installing a custom CheckRedirect removes the
 	// stdlib's own 10-redirect cap, so the policy must re-impose one.
@@ -360,6 +377,7 @@ func runHTTP(ctx context.Context, cfg *Config, logger *slog.Logger, httpClient *
 		ReadHeaderTimeout: readHeaderTimeout,
 		WriteTimeout:      writeTimeout,
 		IdleTimeout:       idleTimeout,
+		MaxHeaderBytes:    maxHeaderBytes,
 	}
 
 	// serveCtx lets the shutdown goroutine run cleanup on a ListenAndServe startup
@@ -434,6 +452,16 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		return nil
 	}
 
+	// Bound the attacker-controlled host BEFORE it reaches safeHost, hostAllowed or
+	// any other work: safeHost's redaction cost scales with input length, and this
+	// runs on an unauthenticated request, so an unbounded header is a DoS lever
+	// (issue #76). Only the length is logged, never the (potentially huge) host
+	// content, which is the cost being defended against.
+	if len(host) > maxHostHeaderBytes {
+		logger.Error("gateway: X-Centreon-Host header too long", "len", len(host), "max", maxHostHeaderBytes)
+		return nil
+	}
+
 	if !hostAllowed(host, cfg.AllowedHosts) {
 		logger.Error("gateway: host not in allowlist", "host", safeHost(host))
 		return nil
@@ -480,8 +508,40 @@ func gatewayServer(r *http.Request, cfg *Config, tokenCache *TokenCache, logger 
 		}
 	}
 
+	// A caller-supplied token (token != "") skips the password login above, so
+	// nothing has authenticated it yet. Validate it before building the per-request
+	// tool registry, so an unauthenticated caller cannot force a registry build with
+	// an arbitrary token (issue #79). Anchor on the request header token, NOT
+	// gwCfg.Token: a token minted by our own password login (the cache path above)
+	// is already trusted and must not be revalidated.
+	if token != "" && !validateGatewayToken(r.Context(), tokenCache, client, host, token, logger) {
+		return nil
+	}
+
 	logger.Debug("gateway: created per-request client", "host", safeHost(host))
 	return buildServer(client, logger, displayHost(host), cfg.ReadOnly)
+}
+
+// validateGatewayToken authenticates a caller-supplied gateway token against
+// Centreon before the per-request tool registry is built (issue #79), returning
+// false if it fails. A successful validation is remembered in tokenCache so a repeat
+// caller does not pay an upstream round-trip per request; the entry uses an EMPTY
+// stored token as a "validated" sentinel. The empty value is deliberate: it is the
+// token PARAMETER that carries the cache key, and shutdown's Drain/logoutCachedToken
+// no-ops on an empty stored token, so this caller-owned API token is never logged
+// out from under its owner. Do not "simplify" by storing the token itself: that
+// would make shutdown try to log out a token we do not own.
+func validateGatewayToken(ctx context.Context, tokenCache *TokenCache, client *centreon.Client, host, token string, logger *slog.Logger) bool {
+	if _, ok := tokenCache.Get(host, "", token); ok {
+		return true
+	}
+	if err := checkCredentials(ctx, client); err != nil {
+		logger.Error("gateway: token validation failed", "host", safeHost(host), "error", redact.Reason(err))
+		return false
+	}
+	tokenCache.Set(host, "", token, "")
+	logger.Debug("gateway: token validated", "host", safeHost(host))
+	return true
 }
 
 // hostAllowed reports whether host may be used in gateway mode. An empty

--- a/server_test.go
+++ b/server_test.go
@@ -48,19 +48,20 @@ func TestHostAllowed(t *testing.T) {
 	}
 }
 
-// TestGatewayServer_HostAllowlist exercises the enforcement point itself, not
-// just the hostAllowed helper: it confirms gatewayServer rejects a host that is
-// not on the allowlist (returns nil) and admits one that is. A token is
-// supplied so the token branch is taken and no network login is attempted.
+// TestGatewayServer_HostAllowlist exercises the enforcement point itself, not just
+// the hostAllowed helper: gatewayServer must reject a host off the allowlist and a
+// cleartext scheme, and admit an allowed one. Since #79 an accepted host must answer
+// the token-validation read, so the accept cases point at a fake that accepts any
+// token. The reject cases assert on the specific rejection-reason LOG, not only a
+// nil server: deleting the allowlist or scheme check would fall through to token
+// validation, which also returns nil against the unreachable reject host, so a bare
+// nil check could not tell the two rejections apart (or catch either check's
+// removal).
 func TestGatewayServer_HostAllowlist(t *testing.T) {
-	logger := slog.New(slog.DiscardHandler)
 	cache := NewTokenCache(time.Minute)
 
-	// Since #79, gatewayServer validates a caller-supplied token before building, so
-	// an accepted host must actually answer the validation read. This fake accepts
-	// any token, keeping the focus of each subtest on allowlist/scheme enforcement
-	// rather than authentication. It is loopback http, hence AllowHTTP on the accept
-	// cases.
+	// A fake Centreon that accepts any token, so the accept cases reach a real
+	// (loopback http, hence AllowHTTP) host and clear token validation.
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{})
@@ -68,6 +69,7 @@ func TestGatewayServer_HostAllowlist(t *testing.T) {
 	fake := httptest.NewServer(mux)
 	defer fake.Close()
 
+	discard := slog.New(slog.DiscardHandler)
 	newReq := func(host string) *http.Request {
 		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
 		r.Header.Set("X-Centreon-Host", host)
@@ -76,36 +78,46 @@ func TestGatewayServer_HostAllowlist(t *testing.T) {
 	}
 
 	t.Run("host not in allowlist is rejected", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewJSONHandler(&buf, nil))
 		cfg := &Config{AllowedHosts: []string{"https://allowed.example.com"}}
 		if s := gatewayServer(newReq("https://evil.example.com"), cfg, cache, logger, nil); s != nil {
 			t.Error("expected nil server for host not in allowlist, got non-nil")
+		}
+		if !strings.Contains(buf.String(), "not in allowlist") {
+			t.Errorf("expected the allowlist-rejection log (deleting the allowlist check must be caught here), got: %s", buf.String())
 		}
 	})
 
 	t.Run("host in allowlist is accepted", func(t *testing.T) {
 		cfg := &Config{AllowHTTP: true, AllowedHosts: []string{fake.URL}}
-		if s := gatewayServer(newReq(fake.URL), cfg, cache, logger, nil); s == nil {
+		if s := gatewayServer(newReq(fake.URL), cfg, cache, discard, nil); s == nil {
 			t.Error("expected non-nil server for allowed host, got nil")
 		}
 	})
 
 	t.Run("empty allowlist accepts any host", func(t *testing.T) {
 		cfg := &Config{AllowHTTP: true}
-		if s := gatewayServer(newReq(fake.URL), cfg, cache, logger, nil); s == nil {
+		if s := gatewayServer(newReq(fake.URL), cfg, cache, discard, nil); s == nil {
 			t.Error("expected non-nil server when allowlist is empty, got nil")
 		}
 	})
 
 	t.Run("http host rejected when AllowHTTP is false", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewJSONHandler(&buf, nil))
 		cfg := &Config{}
 		if s := gatewayServer(newReq("http://plain.example.com"), cfg, cache, logger, nil); s != nil {
 			t.Error("expected nil server for cleartext http host without CENTREON_ALLOW_HTTP, got non-nil")
+		}
+		if !strings.Contains(buf.String(), "host rejected") {
+			t.Errorf("expected the scheme-rejection log (deleting the scheme check must be caught here), got: %s", buf.String())
 		}
 	})
 
 	t.Run("http host accepted when AllowHTTP is true", func(t *testing.T) {
 		cfg := &Config{AllowHTTP: true}
-		if s := gatewayServer(newReq(fake.URL), cfg, cache, logger, nil); s == nil {
+		if s := gatewayServer(newReq(fake.URL), cfg, cache, discard, nil); s == nil {
 			t.Error("expected non-nil server for http host with CENTREON_ALLOW_HTTP, got nil")
 		}
 	})

--- a/server_test.go
+++ b/server_test.go
@@ -56,6 +56,18 @@ func TestGatewayServer_HostAllowlist(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	cache := NewTokenCache(time.Minute)
 
+	// Since #79, gatewayServer validates a caller-supplied token before building, so
+	// an accepted host must actually answer the validation read. This fake accepts
+	// any token, keeping the focus of each subtest on allowlist/scheme enforcement
+	// rather than authentication. It is loopback http, hence AllowHTTP on the accept
+	// cases.
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	fake := httptest.NewServer(mux)
+	defer fake.Close()
+
 	newReq := func(host string) *http.Request {
 		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
 		r.Header.Set("X-Centreon-Host", host)
@@ -65,38 +77,341 @@ func TestGatewayServer_HostAllowlist(t *testing.T) {
 
 	t.Run("host not in allowlist is rejected", func(t *testing.T) {
 		cfg := &Config{AllowedHosts: []string{"https://allowed.example.com"}}
-		if srv := gatewayServer(newReq("https://evil.example.com"), cfg, cache, logger, nil); srv != nil {
+		if s := gatewayServer(newReq("https://evil.example.com"), cfg, cache, logger, nil); s != nil {
 			t.Error("expected nil server for host not in allowlist, got non-nil")
 		}
 	})
 
 	t.Run("host in allowlist is accepted", func(t *testing.T) {
-		cfg := &Config{AllowedHosts: []string{"https://allowed.example.com"}}
-		if srv := gatewayServer(newReq("https://allowed.example.com"), cfg, cache, logger, nil); srv == nil {
+		cfg := &Config{AllowHTTP: true, AllowedHosts: []string{fake.URL}}
+		if s := gatewayServer(newReq(fake.URL), cfg, cache, logger, nil); s == nil {
 			t.Error("expected non-nil server for allowed host, got nil")
 		}
 	})
 
 	t.Run("empty allowlist accepts any host", func(t *testing.T) {
-		cfg := &Config{}
-		if srv := gatewayServer(newReq("https://anything.example.com"), cfg, cache, logger, nil); srv == nil {
+		cfg := &Config{AllowHTTP: true}
+		if s := gatewayServer(newReq(fake.URL), cfg, cache, logger, nil); s == nil {
 			t.Error("expected non-nil server when allowlist is empty, got nil")
 		}
 	})
 
 	t.Run("http host rejected when AllowHTTP is false", func(t *testing.T) {
 		cfg := &Config{}
-		if srv := gatewayServer(newReq("http://plain.example.com"), cfg, cache, logger, nil); srv != nil {
+		if s := gatewayServer(newReq("http://plain.example.com"), cfg, cache, logger, nil); s != nil {
 			t.Error("expected nil server for cleartext http host without CENTREON_ALLOW_HTTP, got non-nil")
 		}
 	})
 
 	t.Run("http host accepted when AllowHTTP is true", func(t *testing.T) {
 		cfg := &Config{AllowHTTP: true}
-		if srv := gatewayServer(newReq("http://plain.example.com"), cfg, cache, logger, nil); srv == nil {
+		if s := gatewayServer(newReq(fake.URL), cfg, cache, logger, nil); s == nil {
 			t.Error("expected non-nil server for http host with CENTREON_ALLOW_HTTP, got nil")
 		}
 	})
+}
+
+// TestGatewayServer_RejectsOversizedHostHeader pins issue #76: gatewayServer must
+// reject an X-Centreon-Host header longer than maxHostHeaderBytes BEFORE it reaches
+// safeHost or any credential handling, and must never log the host content (logging
+// even a "redacted" oversized host is the O(len) redaction cost the cap exists to
+// defend against). Input shapes are varied deliberately (padding location, escape
+// placement, allowlisted vs not) because this file's history shows a single fixed
+// shape lets fail-open bugs survive a sabotage pass.
+func TestGatewayServer_RejectsOversizedHostHeader(t *testing.T) {
+	t.Parallel()
+
+	const marker = "oversized-host-marker-must-not-be-logged"
+
+	newReq := func(host string) *http.Request {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+		r.Header.Set("X-Centreon-Host", host)
+		r.Header.Set("X-Centreon-Token", "dummy-token")
+		return r
+	}
+
+	tests := []struct {
+		name        string
+		host        string
+		allowlisted bool
+	}{
+		{
+			name: "just over the cap, padding in path, escape at end",
+			host: "https://" + marker + ".example.com/" + strings.Repeat("a", maxHostHeaderBytes) + "%",
+		},
+		{
+			name: "one megabyte, padding in query, escape mid-string",
+			host: "https://" + marker + ".example.com/?q=" + strings.Repeat("b", 512<<10) + "%25" + strings.Repeat("c", 512<<10),
+		},
+		{
+			// The host equals an allowlist entry: without the length gate the flow
+			// would reach hostAllowed (true) and build a server, so this pins that the
+			// cap precedes the allowlist check.
+			name:        "oversized host that is on the allowlist is still rejected",
+			host:        "https://" + marker + ".example.com/" + strings.Repeat("d", maxHostHeaderBytes),
+			allowlisted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if len(tt.host) <= maxHostHeaderBytes {
+				t.Fatalf("test host is not oversized: len=%d cap=%d", len(tt.host), maxHostHeaderBytes)
+			}
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			cache := NewTokenCache(time.Minute)
+
+			cfg := &Config{}
+			if tt.allowlisted {
+				cfg.AllowedHosts = []string{tt.host}
+			}
+
+			if srv := gatewayServer(newReq(tt.host), cfg, cache, logger, nil); srv != nil {
+				t.Fatal("expected nil server for oversized X-Centreon-Host, got non-nil")
+			}
+			if out := buf.String(); strings.Contains(out, marker) {
+				t.Errorf("oversized host content must not be logged (DoS cost / CWE-532), got: %s", out)
+			}
+		})
+	}
+}
+
+// TestRunHTTP_RejectsOversizedRequestHeaders pins issue #76: runHTTP must set
+// MaxHeaderBytes so the server answers a request whose headers exceed the cap with
+// 431 instead of buffering up to Go's 1 MiB default. The oversize is placed in a
+// single header in one subtest and spread across many in another, since
+// MaxHeaderBytes bounds the TOTAL header size, not one field.
+func TestRunHTTP_RejectsOversizedRequestHeaders(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	port := freePort(t)
+	cfg := &Config{
+		Host:      "https://unused.example.com", // required field; unused in gateway mode
+		Transport: transportHTTP,
+		AuthMode:  authModeGateway,
+		HTTPHost:  "127.0.0.1",
+		HTTPPort:  port,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- runHTTP(ctx, cfg, logger, nil) }()
+
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+	waitForHealth(t, base+"/health")
+
+	tests := []struct {
+		name    string
+		setHdrs func(*http.Request)
+	}{
+		{
+			name: "bulk in one X-Centreon-Host header",
+			setHdrs: func(r *http.Request) {
+				r.Header.Set("X-Centreon-Host", strings.Repeat("z", maxHeaderBytes+(8<<10)))
+			},
+		},
+		{
+			name: "bulk spread across many headers",
+			setHdrs: func(r *http.Request) {
+				chunk := strings.Repeat("z", 8<<10)
+				for i := 0; i < (maxHeaderBytes/(8<<10))+2; i++ {
+					r.Header.Set(fmt.Sprintf("X-Junk-%d", i), chunk)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/health", http.NoBody)
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			tt.setHdrs(req)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusRequestHeaderFieldsTooLarge {
+				t.Errorf("expected 431 for oversized headers, got %d", resp.StatusCode)
+			}
+		})
+	}
+
+	// A normal request stays under the cap and still succeeds.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/health", http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("normal /health request should return 200, got %d", resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("runHTTP did not return within 15s after context cancel")
+	}
+}
+
+// TestGatewayServer_HostCapBoundaryIsExclusive pins that the #76 length gate is
+// '>', not '>=': a host of exactly maxHostHeaderBytes must pass the gate. We prove
+// it passed by observing that it reaches the NEXT check (the allowlist) rather than
+// the "header too long" rejection.
+func TestGatewayServer_HostCapBoundaryIsExclusive(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	host := "https://boundary.example.com/"
+	host += strings.Repeat("a", maxHostHeaderBytes-len(host))
+	if len(host) != maxHostHeaderBytes {
+		t.Fatalf("host must be exactly the cap: len=%d cap=%d", len(host), maxHostHeaderBytes)
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+	req.Header.Set("X-Centreon-Host", host)
+	req.Header.Set("X-Centreon-Token", "tok")
+
+	// A non-empty allowlist that does NOT contain the host, so the expected outcome
+	// past the length gate is an allowlist rejection.
+	cfg := &Config{AllowedHosts: []string{"https://a-different-allowed-host.example.com"}}
+	if s := gatewayServer(req, cfg, NewTokenCache(time.Minute), logger, nil); s != nil {
+		t.Fatal("expected nil (rejected by allowlist), got non-nil")
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "too long") {
+		t.Errorf("a host of exactly the cap must NOT trip the length gate, got: %s", out)
+	}
+	if !strings.Contains(out, "not in allowlist") {
+		t.Errorf("a host of exactly the cap should reach the allowlist check, got: %s", out)
+	}
+}
+
+// TestGatewayServer_ValidatesTokenBeforeBuild pins issue #79: a caller-supplied
+// X-Centreon-Token must be validated against Centreon BEFORE gatewayServer builds
+// the (expensive) tool registry, so an unauthenticated caller cannot force a
+// per-request registry build. Inputs are varied (token value, allowlist state) so
+// no single hidden constant carries the test.
+func TestGatewayServer_ValidatesTokenBeforeBuild(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	const goodToken = "valid-tok-3"
+
+	var statusHits atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, r *http.Request) {
+		statusHits.Add(1)
+		if r.Header.Get("X-AUTH-TOKEN") != goodToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	fake := httptest.NewServer(mux)
+	defer fake.Close()
+
+	newReq := func(token string) *http.Request {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+		r.Header.Set("X-Centreon-Host", fake.URL)
+		r.Header.Set("X-Centreon-Token", token)
+		return r
+	}
+
+	tests := []struct {
+		name      string
+		token     string
+		allowlist []string
+		wantNil   bool
+	}{
+		{"bad token is rejected before build (empty allowlist)", "wrong-tok", nil, true},
+		{"bad token rejected even when the host is allowlisted", "another-wrong-tok", []string{fake.URL}, true},
+		{"valid token builds a server", goodToken, []string{fake.URL}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusHits.Store(0)
+			cfg := &Config{AllowHTTP: true, AllowedHosts: tt.allowlist}
+			s := gatewayServer(newReq(tt.token), cfg, NewTokenCache(time.Minute), logger, nil)
+			if tt.wantNil && s != nil {
+				t.Fatal("expected nil server for a token that fails validation, got non-nil")
+			}
+			if !tt.wantNil && s == nil {
+				t.Fatal("expected non-nil server for a valid token, got nil")
+			}
+			if got := statusHits.Load(); got != 1 {
+				t.Errorf("expected exactly one token-validation read against Centreon, got %d", got)
+			}
+		})
+	}
+}
+
+// TestGatewayServer_CachesTokenValidation pins the perf half of the #79 containment:
+// a repeated valid token reuses the cached validation and does NOT re-hit Centreon,
+// while a DISTINCT token validates separately (the token is part of the cache key,
+// guarding the fail-open shape where the cache would match any token).
+func TestGatewayServer_CachesTokenValidation(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	const (
+		tokA = "cache-tok-A"
+		tokB = "cache-tok-B"
+	)
+
+	var statusHits atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /centreon/api/latest/monitoring/hosts/status", func(w http.ResponseWriter, r *http.Request) {
+		statusHits.Add(1)
+		if tok := r.Header.Get("X-AUTH-TOKEN"); tok != tokA && tok != tokB {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	fake := httptest.NewServer(mux)
+	defer fake.Close()
+
+	cfg := &Config{AllowHTTP: true}
+	cache := NewTokenCache(time.Minute)
+
+	newReq := func(token string) *http.Request {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", http.NoBody)
+		r.Header.Set("X-Centreon-Host", fake.URL)
+		r.Header.Set("X-Centreon-Token", token)
+		return r
+	}
+
+	// Same token twice: the second request reuses the cached validation.
+	if s := gatewayServer(newReq(tokA), cfg, cache, logger, nil); s == nil {
+		t.Fatal("request 1: expected non-nil server for a valid token")
+	}
+	if s := gatewayServer(newReq(tokA), cfg, cache, logger, nil); s == nil {
+		t.Fatal("request 2: expected non-nil server for a valid token")
+	}
+	if got := statusHits.Load(); got != 1 {
+		t.Fatalf("the same token twice should validate against Centreon exactly once, got %d", got)
+	}
+
+	// A distinct token must not match the cached entry, so it validates separately.
+	if s := gatewayServer(newReq(tokB), cfg, cache, logger, nil); s == nil {
+		t.Fatal("request 3: expected non-nil server for a second valid token")
+	}
+	if got := statusHits.Load(); got != 2 {
+		t.Fatalf("a distinct token must validate separately (token is in the cache key), got %d validations", got)
+	}
 }
 
 // TestGatewayServer_RedactsUserinfoInHostLogs pins issue #41: a gateway host URL

--- a/tools/acknowledgement_tools.go
+++ b/tools/acknowledgement_tools.go
@@ -115,7 +115,7 @@ func acknowledgementHostListHandler(client *centreon.Client, logger *slog.Logger
 			res, anyVal := errorResult("failed to list acknowledgements for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }
@@ -133,7 +133,7 @@ func acknowledgementServiceListHandler(client *centreon.Client, logger *slog.Log
 			res, anyVal := errorResult("failed to list acknowledgements for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }

--- a/tools/common_list_redact_test.go
+++ b/tools/common_list_redact_test.go
@@ -31,3 +31,28 @@ func TestCommonListHandler_ErrorNeverEchoesCredential(t *testing.T) {
 		t.Errorf("want the tool named and the reason classified, got: %q", text)
 	}
 }
+
+// TestCommonListHandler_NilResultSerializesAsArray pins #85: a successful list
+// whose underlying Result slice is nil (a 204, a body with result:null, or an
+// omitted result) must serialize as "result": [] so a client never has to
+// special-case null.
+func TestCommonListHandler_NilResultSerializesAsArray(t *testing.T) {
+	requester := func(_ context.Context, _ ...centreon.ListOption) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+		return &centreon.ListResponse[centreon.MonitoringServer]{Result: nil}, nil
+	}
+
+	res, _, err := commonListHandler(t.Context(), testLogger(t), "centreon_host_list", ListInput{}, requester)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %q", textOf(t, res))
+	}
+	text := textOf(t, res)
+	if strings.Contains(text, `"result": null`) {
+		t.Errorf("nil Result must not serialize as null, got: %q", text)
+	}
+	if !strings.Contains(text, `"result": []`) {
+		t.Errorf("nil Result must serialize as an empty array, got: %q", text)
+	}
+}

--- a/tools/downtime_tools.go
+++ b/tools/downtime_tools.go
@@ -139,7 +139,7 @@ func downtimeHostListHandler(client *centreon.Client, logger *slog.Logger) func(
 			res, anyVal := errorResult("failed to list downtimes for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }
@@ -157,7 +157,7 @@ func downtimeServiceListHandler(client *centreon.Client, logger *slog.Logger) fu
 			res, anyVal := errorResult("failed to list downtimes for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }

--- a/tools/monitoring_tools.go
+++ b/tools/monitoring_tools.go
@@ -99,7 +99,7 @@ func monitoringHostListHandler(client *centreon.Client, logger *slog.Logger) fun
 			return res, anyVal, nil
 		}
 		logger.Debug("centreon_monitoring_host_list completed", "results", len(resp.Result), "total", resp.Meta.Total)
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }
@@ -133,7 +133,7 @@ func monitoringHostServicesHandler(client *centreon.Client, logger *slog.Logger)
 			res, anyVal := errorResult("failed to list services for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }
@@ -151,7 +151,7 @@ func monitoringHostTimelineHandler(client *centreon.Client, logger *slog.Logger)
 			res, anyVal := errorResult("failed to get timeline for host %d: %s", in.HostID, reason)
 			return res, anyVal, nil
 		}
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }
@@ -185,7 +185,7 @@ func monitoringServiceListHandler(client *centreon.Client, logger *slog.Logger) 
 			return res, anyVal, nil
 		}
 		logger.Debug("centreon_monitoring_service_list completed", "results", len(resp.Result), "total", resp.Meta.Total)
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }
@@ -239,7 +239,7 @@ func monitoringServiceTimelineHandler(client *centreon.Client, logger *slog.Logg
 			res, anyVal := errorResult("failed to get timeline for service (host=%d, service=%d): %s", in.HostID, in.ServiceID, reason)
 			return res, anyVal, nil
 		}
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }
@@ -437,7 +437,7 @@ func monitoringResourceListHandler(client *centreon.Client, logger *slog.Logger)
 			return res, anyVal, nil
 		}
 		logger.Debug("centreon_monitoring_resource_list completed", "results", len(resp.Result), "total", resp.Meta.Total)
-		res, anyVal := jsonResult(resp)
+		res, anyVal := listResult(resp)
 		return res, anyVal, nil
 	}
 }

--- a/tools/monitoring_tools_test.go
+++ b/tools/monitoring_tools_test.go
@@ -216,6 +216,38 @@ func TestMonitoringResourceListHandler_SendsSearchAndSortParams(t *testing.T) {
 	}
 }
 
+// TestMonitoringListHandler_NilResultSerializesAsArray pins #85 across the
+// monitoring list surface, not only the commonListHandler tools: a 204 No Content
+// leaves the client's Result nil, which must still serialize as [] not null (the
+// monitoring handlers route through listResult like every other list tool).
+func TestMonitoringListHandler_NilResultSerializesAsArray(t *testing.T) {
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer fake.Close()
+
+	client, err := centreon.NewClient(fake.URL, centreon.WithAPIToken("t"))
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	handler := monitoringHostListHandler(client, testLogger(t))
+	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, MonitoringListInput{})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %s", textOf(t, res))
+	}
+	text := textOf(t, res)
+	if strings.Contains(text, `"result": null`) {
+		t.Errorf("nil Result must not serialize as null, got: %q", text)
+	}
+	if !strings.Contains(text, `"result": []`) {
+		t.Errorf("nil Result must serialize as an empty array, got: %q", text)
+	}
+}
+
 func TestMonitoringResourceListHandler_InvalidInputSkipsAPI(t *testing.T) {
 	var calls atomic.Int64
 	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tools/operations_tools.go
+++ b/tools/operations_tools.go
@@ -27,7 +27,7 @@ func RegisterOperationsTools(s *Registrar, client *centreon.Client, logger *slog
 	addTool(s, &mcp.Tool{
 		Name:        "centreon_resource_check",
 		Description: "Force the monitoring engine to run an active check of a host or service right now instead of waiting for its next scheduled check, identifying the resource by type (host or service) and id, plus the parent host id for a service. Use this to refresh state on demand after a suspected recovery; use centreon_resource_submit instead to push an externally computed result rather than triggering the engine's own check. The check runs asynchronously and updates the resource's live status and output once it completes. Writes to Centreon.",
-		Annotations: updateTool("Force resource check"),
+		Annotations: forceCheckTool("Force resource check"),
 	}, bulkCheckHandler(client, logger))
 
 	addTool(s, &mcp.Tool{

--- a/tools/readonly_test.go
+++ b/tools/readonly_test.go
@@ -264,3 +264,38 @@ func TestAnnotations_SubmitAndCheckAreDestructive(t *testing.T) {
 		}
 	}
 }
+
+// TestAnnotations_ForceCheckIsNotIdempotent pins #91 item 1: forcing an on-demand
+// check schedules a fresh check on every call, so centreon_resource_check must NOT
+// advertise IdempotentHint (a client honoring it could auto-retry and trigger
+// repeated checks). centreon_resource_submit overwrites to a fixed state and is
+// genuinely idempotent, so it keeps IdempotentHint.
+func TestAnnotations_ForceCheckIsNotIdempotent(t *testing.T) {
+	ctx := t.Context()
+	cs := registerAllSession(t, ctx, &centreon.Client{}, false)
+
+	wantIdempotent := map[string]bool{"centreon_resource_check": false, "centreon_resource_submit": true}
+	seen := map[string]bool{}
+	for tool, err := range cs.Tools(ctx, nil) {
+		if err != nil {
+			t.Fatalf("listing tools: %v", err)
+		}
+		want, ok := wantIdempotent[tool.Name]
+		if !ok {
+			continue
+		}
+		seen[tool.Name] = true
+		if tool.Annotations == nil {
+			t.Errorf("%s has no annotations", tool.Name)
+			continue
+		}
+		if tool.Annotations.IdempotentHint != want {
+			t.Errorf("%s IdempotentHint = %v, want %v", tool.Name, tool.Annotations.IdempotentHint, want)
+		}
+	}
+	for name := range wantIdempotent {
+		if !seen[name] {
+			t.Errorf("tool %q was not found among registered tools", name)
+		}
+	}
+}

--- a/tools/status_tools.go
+++ b/tools/status_tools.go
@@ -124,6 +124,9 @@ func platformStatusHandlerFn(
 			return res, anyVal, nil
 		}
 
+		// Normalize the embedded server list so a nil Result nests as [] not null,
+		// the same guarantee the dedicated list tools give (#85).
+		normalizeList(servers)
 		status := PlatformStatus{
 			Host:     host,
 			Hosts:    hosts,

--- a/tools/status_tools_test.go
+++ b/tools/status_tools_test.go
@@ -99,6 +99,37 @@ func TestPlatformStatusHandlerFn_CombinesResults(t *testing.T) {
 	}
 }
 
+// TestPlatformStatusHandlerFn_NilServersSerializeAsArray pins #85 for the embedded
+// server list: a nil Servers.Result must nest as [] not null in the composite
+// platform_status output, the same guarantee the dedicated list tools give.
+func TestPlatformStatusHandlerFn_NilServersSerializeAsArray(t *testing.T) {
+	fetchHosts := func(_ context.Context) (*centreon.HostStatusCount, error) {
+		return &centreon.HostStatusCount{}, nil
+	}
+	fetchServices := func(_ context.Context) (*centreon.ServiceStatusCount, error) {
+		return &centreon.ServiceStatusCount{}, nil
+	}
+	fetchServers := func(_ context.Context) (*centreon.ListResponse[centreon.MonitoringServer], error) {
+		return &centreon.ListResponse[centreon.MonitoringServer]{Result: nil}, nil
+	}
+
+	handler := platformStatusHandlerFn(fetchHosts, fetchServices, fetchServers, testLogger(t), testStatusHost)
+	res, _, err := handler(t.Context(), &mcp.CallToolRequest{}, struct{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error result: %s", textOf(t, res))
+	}
+	text := textOf(t, res)
+	if strings.Contains(text, `"result": null`) {
+		t.Errorf("embedded nil server list must not serialize as null, got: %q", text)
+	}
+	if !strings.Contains(text, `"result": []`) {
+		t.Errorf("embedded nil server list must serialize as an empty array, got: %q", text)
+	}
+}
+
 // TestPlatformStatusHandlerFn_RunsConcurrently proves the three reads run in
 // parallel: each fetcher blocks until every fetcher has started. A sequential
 // implementation can never get all three started at once, so it fails to reach

--- a/tools/tdqs_test.go
+++ b/tools/tdqs_test.go
@@ -62,19 +62,7 @@ func TestTDQS_ToolDefinitionsQuality(t *testing.T) {
 	s := mcp.NewServer(&mcp.Implementation{Name: "centreon-mcp-go", Version: "test"}, nil)
 	RegisterAll(s, &centreon.Client{}, nil, "https://tdqs.example.com", false)
 
-	clientTransport, serverTransport := mcp.NewInMemoryTransports()
-	ss, err := s.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		t.Fatalf("server connect: %v", err)
-	}
-	t.Cleanup(func() { _ = ss.Close() })
-
-	c := mcp.NewClient(&mcp.Implementation{Name: "tdqs-test", Version: "0"}, nil)
-	cs, err := c.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		t.Fatalf("client connect: %v", err)
-	}
-	t.Cleanup(func() { _ = cs.Close() })
+	cs := connectServerSession(t, ctx, s)
 
 	count := 0
 	for tool, iterErr := range cs.Tools(ctx, nil) {

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -91,6 +91,15 @@ func deleteTool(title string) *mcp.ToolAnnotations {
 	return &mcp.ToolAnnotations{Title: title, DestructiveHint: new(true), IdempotentHint: true, OpenWorldHint: new(true)}
 }
 
+// forceCheckTool annotates a tool that forces the monitoring engine to run an
+// on-demand active check. It is destructive (it overwrites the resource's live
+// status and output) but, unlike updateTool, NOT idempotent: each call schedules a
+// fresh check, so a client that honors IdempotentHint must not auto-retry it (#91).
+// It carries no ReadOnlyHint, so read-only mode still refuses it.
+func forceCheckTool(title string) *mcp.ToolAnnotations {
+	return &mcp.ToolAnnotations{Title: title, DestructiveHint: new(true), IdempotentHint: false, OpenWorldHint: new(true)}
+}
+
 // ListInput is the common input for list tools.
 type ListInput struct {
 	Page   int    `json:"page,omitempty"   jsonschema:"Page number (default 1)"`
@@ -220,6 +229,28 @@ func jsonResult(data any) (res *mcp.CallToolResult, anyVal any) {
 	}, nil
 }
 
+// normalizeList replaces a nil Result slice with an empty one, so a list response
+// serializes as an empty array rather than null. The client returns a nil slice for
+// a 204 No Content, a body with `result: null`, or a body that omits `result`, all
+// of which would otherwise become `"result": null` and force a consumer to
+// special-case null (#85). It is used both by listResult (the top-level list-tool
+// path) and directly by composite tools that embed a ListResponse field.
+func normalizeList[T any](resp *centreon.ListResponse[T]) {
+	if resp != nil && resp.Result == nil {
+		resp.Result = []T{}
+	}
+}
+
+// listResult serializes a paginated list response, normalizing a nil Result slice
+// first so the output is always a JSON array, never null (#85). Every tool whose
+// result IS a *centreon.ListResponse[T] routes through here; a composite tool that
+// merely embeds a ListResponse field calls normalizeList on that field directly
+// (see centreon_platform_status).
+func listResult[T any](resp *centreon.ListResponse[T]) (res *mcp.CallToolResult, anyVal any) {
+	normalizeList(resp)
+	return jsonResult(resp)
+}
+
 // errorResult builds an error result with IsError: true.
 func errorResult(format string, args ...any) (res *mcp.CallToolResult, anyVal any) {
 	text := fmt.Sprintf(format, args...)
@@ -322,6 +353,6 @@ func commonListHandler[T any](
 
 	logger.Debug(toolName+" completed", "results", len(resp.Result), "total", resp.Meta.Total, "page", resp.Meta.Page)
 
-	res, anyVal := jsonResult(resp)
+	res, anyVal := listResult(resp)
 	return res, anyVal, nil
 }


### PR DESCRIPTION
## Summary

This bundles the gateway-hardening work with two folded backlog fixes, all reviewed through the pre-push gate (three review rounds plus Gemini cross-check).

**#76 (security, DoS).** In gateway (multi-tenant HTTP) mode the `X-Centreon-Host` header was unbounded, so an unauthenticated request could send a ~1 MiB header that reached the length-scaling `safeHost` credential-redaction path before any auth check, costing tens of milliseconds and megabytes of allocation per request. `gatewayServer` now rejects a host header over 2048 bytes (sourced from the existing `maxCachedHostLen`, so the two host bounds cannot drift) before it reaches redaction, logging only the length. The HTTP server also sets `MaxHeaderBytes` to 64 KiB (down from Go's 1 MiB default), in both env-auth and gateway transport, so oversized headers get a 431 before any handler runs.

**#79 (perf/security containment).** In the token branch a caller-supplied `X-Centreon-Token` was never validated before `buildServer` ran, so an unauthenticated caller with any allowlisted host and an arbitrary token could force a full per-request tool-registry build (measured at tens of thousands of allocations). The token is now validated against Centreon (via the existing `checkCredentials`, a `/monitoring/hosts/status` read) before the registry is built. Successful validations are cached in the existing token cache using an empty-token sentinel keyed `(host, "", token)`, so a repeat caller pays no extra round-trip and shutdown never logs out the caller-owned token. The remaining per-request registry rebuild for already-valid callers is the larger refactor, tracked separately in #94.

**#85 (folded).** List tool results now always serialize `result` as a JSON array. A shared `normalizeList[T]` helper replaces a nil `Result` slice with an empty one; every handler whose result is a `*ListResponse[T]` routes through `listResult`. Besides the config/infra list tools (already covered by `commonListHandler`), the ten list-shaped handlers that called `jsonResult` directly are converted (six monitoring, two acknowledgement, two downtime), and `centreon_platform_status` normalizes its embedded server list too.

**#91 (folded, partial).** `centreon_resource_check` no longer advertises `idempotentHint`: forcing an on-demand check schedules a fresh check on every call, so it is destructive but not idempotent (a client honoring the hint could otherwise auto-retry). `centreon_resource_submit`, which overwrites to a fixed state, stays idempotent. Also dedupes the tdqs test onto the shared `connectServerSession` helper (items 1 and 3 of the batch).

## Related Issues

Fixes #76. Fixes #85. Addresses the security half of #79 (per-request registry rebuild tracked in #94). Addresses items 1 and 3 of #91. Follow-ups filed: #94 (registry-once refactor), #95 (low-severity gate findings).

## Test Plan

- [x] `go build ./... && go vet ./...` clean
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go test ./...` green (all packages)
- [x] New tests sabotage-verified: each was confirmed to fail when its target production line is removed (header cap, MaxHeaderBytes 431, token validate-before-build, validation caching, allowlist/scheme rejection logs, nil-result normalization across common/monitoring/platform_status paths, resource_check non-idempotence)